### PR TITLE
Mbp 303 add two air pressure sensor groups

### DIFF
--- a/DUTs/Pneumatics/E_PneumaticAxisGroup.TcDUT
+++ b/DUTs/Pneumatics/E_PneumaticAxisGroup.TcDUT
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <DUT Name="E_PneumaticAxisGroup" Id="{ddf4013f-9aa0-03e5-2424-e1247355bb7f}">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+{attribute 'strict'}
+TYPE E_PneumaticAxisGroup :
+(
+	ePneumaticAxisGroup1 := 1,
+	ePneumaticAxisGroup2 := 2
+);
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/DUTs/Pneumatics/E_PneumaticAxisGroup.TcDUT
+++ b/DUTs/Pneumatics/E_PneumaticAxisGroup.TcDUT
@@ -5,8 +5,8 @@
 {attribute 'strict'}
 TYPE E_PneumaticAxisGroup :
 (
-	ePneumaticAxisGroup1 := 1,
-	ePneumaticAxisGroup2 := 2
+    ePneumaticAxisGroup1 := 1,
+    ePneumaticAxisGroup2 := 2
 );
 END_TYPE
 ]]></Declaration>

--- a/DUTs/Pneumatics/ST_PneumaticAxisConfig.TcDUT
+++ b/DUTs/Pneumatics/ST_PneumaticAxisConfig.TcDUT
@@ -7,6 +7,7 @@ STRUCT
     sPneumaticAxisName: String(32);
     nTimeToExtend: INT; //User defined time for the cylider to extract in seconds
     nTimeToRetract: INT; //User defined time for the cylinder to retract in seconds
+	eSelectPneumaticAxisGroup: E_PneumaticAxisGroup; //Select the pneumatic group 1 or 2, to connect to the correct pressure sensor
     nAllowTimePressureOutOfRange: INT; //User defined allowed time in seconds for the duration of air pressure value fluctuation
     fLowLimitPressureValue: REAL; //User defined value in bar for low limit air pressure value
     fHighLimitPressureValue: REAL; //User defined value in bar for low limit air pressure value

--- a/DUTs/Pneumatics/ST_PneumaticAxisConfig.TcDUT
+++ b/DUTs/Pneumatics/ST_PneumaticAxisConfig.TcDUT
@@ -8,6 +8,7 @@ STRUCT
     nTimeToExtend: INT; //User defined time for the cylider to extract in seconds
     nTimeToRetract: INT; //User defined time for the cylinder to retract in seconds
 	eSelectPneumaticAxisGroup: E_PneumaticAxisGroup; //Select the pneumatic group 1 or 2, to connect to the correct pressure sensor
+	nAirPressureValueRaw: INT; //Raw analog value from pressure sensors
     nAllowTimePressureOutOfRange: INT; //User defined allowed time in seconds for the duration of air pressure value fluctuation
     fLowLimitPressureValue: REAL; //User defined value in bar for low limit air pressure value
     fHighLimitPressureValue: REAL; //User defined value in bar for low limit air pressure value

--- a/DUTs/Pneumatics/ST_PneumaticAxisConfig.TcDUT
+++ b/DUTs/Pneumatics/ST_PneumaticAxisConfig.TcDUT
@@ -7,8 +7,8 @@ STRUCT
     sPneumaticAxisName: String(32);
     nTimeToExtend: INT; //User defined time for the cylider to extract in seconds
     nTimeToRetract: INT; //User defined time for the cylinder to retract in seconds
-	eSelectPneumaticAxisGroup: E_PneumaticAxisGroup; //Select the pneumatic group 1 or 2, to connect to the correct pressure sensor
-	nAirPressureValueRaw: INT; //Raw analog value from pressure sensors
+    eSelectPneumaticAxisGroup: E_PneumaticAxisGroup; //Select the pneumatic group 1 or 2, to connect to the correct pressure sensor
+    nAirPressureValueRaw: INT; //Raw analog value from pressure sensors
     nAllowTimePressureOutOfRange: INT; //User defined allowed time in seconds for the duration of air pressure value fluctuation
     fLowLimitPressureValue: REAL; //User defined value in bar for low limit air pressure value
     fHighLimitPressureValue: REAL; //User defined value in bar for low limit air pressure value

--- a/DUTs/Pneumatics/ST_PneumaticAxisInputs.TcDUT
+++ b/DUTs/Pneumatics/ST_PneumaticAxisInputs.TcDUT
@@ -7,7 +7,6 @@ STRUCT
     bEndSwitchBwd AT %I*: BOOL; //End Switch Bwd input
     bSolenoidActive AT %I*: BOOL; //Solenoid valve Extend Input (for single solenoid)
     bPSSPermit AT %I*: BOOL; //Input signal from PSS for the movement
-    nAirPressureValueRaw AT %I*: INT; //Raw value from analog air pressure sensor for pneumatic valve
     fPressureValueScaled: REAL; //Scaled value from analog air pressure sensor for pneumatic valve in bar
     bOpenManual AT %I*: BOOL; //Push button input to extend cylinder
     bCloseManual AT %I*: BOOL; //Push button input to retract the cylinder

--- a/DUTs/Pneumatics/ST_PneumaticAxisStruct.TcDUT
+++ b/DUTs/Pneumatics/ST_PneumaticAxisStruct.TcDUT
@@ -9,7 +9,7 @@ STRUCT
     stPneumaticAxisStatus: ST_PneumaticAxisStatus;
     stPneumaticAxisConfig: ST_PneumaticAxisConfig;
     ePneumaticAxisMode: E_PneumaticMode;
-	ePneumaticAxisGroup: E_PneumaticAxisgroup;
+    ePneumaticAxisGroup: E_PneumaticAxisgroup;
     ePneumaticAxisErrors: E_PneumaticAxisErrors;
 END_STRUCT
 END_TYPE

--- a/DUTs/Pneumatics/ST_PneumaticAxisStruct.TcDUT
+++ b/DUTs/Pneumatics/ST_PneumaticAxisStruct.TcDUT
@@ -9,6 +9,7 @@ STRUCT
     stPneumaticAxisStatus: ST_PneumaticAxisStatus;
     stPneumaticAxisConfig: ST_PneumaticAxisConfig;
     ePneumaticAxisMode: E_PneumaticMode;
+	ePneumaticAxisGroup: E_PneumaticAxisgroup;
     ePneumaticAxisErrors: E_PneumaticAxisErrors;
 END_STRUCT
 END_TYPE

--- a/GVLs/GVL.TcGVL
+++ b/GVLs/GVL.TcGVL
@@ -15,6 +15,12 @@
     iPneumaticAxis: UINT := 1; //Index for for loops while going through pneumatic axes
     fbGetCurTaskIndex: GETCURTASKINDEX;
     bLocalMode: BOOL;
+	nAirPressureSensorGroup1 AT %I*: INT; //Raw value from analog air pressure sensor for pneumatic axes group 1
+	nAirPressureSensorGroup2 AT %I*: INT; //Raw value from analog air pressure sensor for pneumatic axes group 2
+	fLowLimitAirPressureGroup1: REAL; //User defined value in bar for low limit air pressure value for pneumatic axes group 1
+    fHighLimitAirPressureGroup1: REAL; //User defined value in bar for low limit air pressure value for pneumatic axes group 1
+	fLowLimitAirPressureGroup2: REAL; //User defined value in bar for low limit air pressure value for pneumatic axes group 2
+    fHighLimitAirPressureGroup2: REAL; //User defined value in bar for low limit air pressure value for pneumatic axes group 2
 
 END_VAR
 

--- a/GVLs/GVL.TcGVL
+++ b/GVLs/GVL.TcGVL
@@ -15,11 +15,11 @@
     iPneumaticAxis: UINT := 1; //Index for for loops while going through pneumatic axes
     fbGetCurTaskIndex: GETCURTASKINDEX;
     bLocalMode: BOOL;
-	nAirPressureSensorGroup1 AT %I*: INT; //Raw value from analog air pressure sensor for pneumatic axes group 1
-	nAirPressureSensorGroup2 AT %I*: INT; //Raw value from analog air pressure sensor for pneumatic axes group 2
-	fLowLimitAirPressureGroup1: REAL; //User defined value in bar for low limit air pressure value for pneumatic axes group 1
+    nAirPressureSensorGroup1 AT %I*: INT; //Raw value from analog air pressure sensor for pneumatic axes group 1
+    nAirPressureSensorGroup2 AT %I*: INT; //Raw value from analog air pressure sensor for pneumatic axes group 2
+    fLowLimitAirPressureGroup1: REAL; //User defined value in bar for low limit air pressure value for pneumatic axes group 1
     fHighLimitAirPressureGroup1: REAL; //User defined value in bar for low limit air pressure value for pneumatic axes group 1
-	fLowLimitAirPressureGroup2: REAL; //User defined value in bar for low limit air pressure value for pneumatic axes group 2
+    fLowLimitAirPressureGroup2: REAL; //User defined value in bar for low limit air pressure value for pneumatic axes group 2
     fHighLimitAirPressureGroup2: REAL; //User defined value in bar for low limit air pressure value for pneumatic axes group 2
 
 END_VAR

--- a/POUs/Pneumatics/FB_PneumaticAxis.TcPOU
+++ b/POUs/Pneumatics/FB_PneumaticAxis.TcPOU
@@ -519,7 +519,7 @@ mSetInputStatuses();
 mSetAllowedTravelTime();
 
 //Get the value of the air pressure in mb
-_stPneumaticAxis.stPneumaticAxisInputs.fPressureValueScaled := mScaledPressureValue(nRawValue :=  _stPneumaticAxis.stPneumaticAxisInputs.nAirPressureValueRaw, fRawHigh := 30518, fRawLow :=0, fScaledHigh := 10, fScaledLow := 0 );
+mSelectAirPressureSensorGroup();
 
 //Check if air pressure is in range
 mCheckForAirPressureError();
@@ -551,6 +551,27 @@ mScaledPressureValue:= rGradient * nRawValue + rOffset;
 
 
 ]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="mSelectAirPressureSensorGroup" Id="{8416effc-de90-0c76-3051-15a05f13b381}">
+      <Declaration><![CDATA[METHOD mSelectAirPressureSensorGroup 
+
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[CASE _stPneumaticAxis.stPneumaticAxisConfig.eSelectPneumaticAxisGroup OF 
+
+        1:
+		_stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw := nAirPressureSensorGroup1;
+		_stPneumaticAxis.stPneumaticAxisConfig.fLowLimitPressureValue := fLowLimitAirPressureGroup1;
+    	_stPneumaticAxis.stPneumaticAxisConfig.fHighLimitPressureValue := fHighLimitAirPressureGroup1;
+		
+        2:
+		_stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw := nAirPressureSensorGroup2;
+		_stPneumaticAxis.stPneumaticAxisConfig.fLowLimitPressureValue := fLowLimitAirPressureGroup2;
+    	_stPneumaticAxis.stPneumaticAxisConfig.fHighLimitPressureValue := fHighLimitAirPressureGroup2;
+    END_CASE
+
+_stPneumaticAxis.stPneumaticAxisInputs.fPressureValueScaled := mScaledPressureValue(nRawValue :=  _stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw, fRawHigh := 30518, fRawLow :=0, fScaledHigh := 10, fScaledLow := 0 );]]></ST>
       </Implementation>
     </Method>
     <Method Name="mSetAllowedTravelTime" Id="{ee25c044-23c7-095b-0652-d0275aeaa21a}">

--- a/POUs/Pneumatics/FB_PneumaticAxis.TcPOU
+++ b/POUs/Pneumatics/FB_PneumaticAxis.TcPOU
@@ -554,24 +554,25 @@ mScaledPressureValue:= rGradient * nRawValue + rOffset;
       </Implementation>
     </Method>
     <Method Name="mSelectAirPressureSensorGroup" Id="{8416effc-de90-0c76-3051-15a05f13b381}">
-      <Declaration><![CDATA[METHOD mSelectAirPressureSensorGroup 
+      <Declaration><![CDATA[METHOD mSelectAirPressureSensorGroup
 
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[CASE _stPneumaticAxis.stPneumaticAxisConfig.eSelectPneumaticAxisGroup OF 
+        <ST><![CDATA[CASE _stPneumaticAxis.stPneumaticAxisConfig.eSelectPneumaticAxisGroup OF
 
         1:
-		_stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw := nAirPressureSensorGroup1;
-		_stPneumaticAxis.stPneumaticAxisConfig.fLowLimitPressureValue := fLowLimitAirPressureGroup1;
-    	_stPneumaticAxis.stPneumaticAxisConfig.fHighLimitPressureValue := fHighLimitAirPressureGroup1;
-		
+        _stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw := nAirPressureSensorGroup1;
+        _stPneumaticAxis.stPneumaticAxisConfig.fLowLimitPressureValue := fLowLimitAirPressureGroup1;
+        _stPneumaticAxis.stPneumaticAxisConfig.fHighLimitPressureValue := fHighLimitAirPressureGroup1;
+
         2:
-		_stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw := nAirPressureSensorGroup2;
-		_stPneumaticAxis.stPneumaticAxisConfig.fLowLimitPressureValue := fLowLimitAirPressureGroup2;
-    	_stPneumaticAxis.stPneumaticAxisConfig.fHighLimitPressureValue := fHighLimitAirPressureGroup2;
+        _stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw := nAirPressureSensorGroup2;
+        _stPneumaticAxis.stPneumaticAxisConfig.fLowLimitPressureValue := fLowLimitAirPressureGroup2;
+        _stPneumaticAxis.stPneumaticAxisConfig.fHighLimitPressureValue := fHighLimitAirPressureGroup2;
     END_CASE
 
-_stPneumaticAxis.stPneumaticAxisInputs.fPressureValueScaled := mScaledPressureValue(nRawValue :=  _stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw, fRawHigh := 30518, fRawLow :=0, fScaledHigh := 10, fScaledLow := 0 );]]></ST>
+_stPneumaticAxis.stPneumaticAxisInputs.fPressureValueScaled := mScaledPressureValue(nRawValue :=  _stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw, fRawHigh := 30518, fRawLow :=0, fScaledHigh := 10, fScaledLow := 0 );
+]]></ST>
       </Implementation>
     </Method>
     <Method Name="mSetAllowedTravelTime" Id="{ee25c044-23c7-095b-0652-d0275aeaa21a}">

--- a/VISUs/PneumaticsVisu.TcVIS
+++ b/VISUs/PneumaticsVisu.TcVIS
@@ -8517,8 +8517,8 @@
                       <v n="Id">2812299069L</v>
                       <l n="Value" t="ArrayList" cet="NamedStyleColor">
                         <o>
-                          <v n="Color">-1</v>
-                          <v n="CanonicalName">"White"</v>
+                          <v n="Color">-1381912</v>
+                          <v n="CanonicalName">"Element-Background-Color"</v>
                         </o>
                       </l>
                     </o>
@@ -8647,26 +8647,7 @@
                 <v n="VisualElementIdentifier">"GenElemInst_218"</v>
                 <n n="VisualElementOfflinePaintCommands" />
                 <n n="VisualElementFrameInformation" />
-                <d n="VisualElementInputActions" t="Hashtable" ckt="String" cvt="InputBoxInputAction[]">
-                  <v>OnMouseClick</v>
-                  <a cet="InputBoxInputAction">
-                    <o>
-                      <v n="InputBoxVariable">""</v>
-                      <v n="InputType">"Default"</v>
-                      <v n="InputBoxMin">""</v>
-                      <v n="InputBoxMax">""</v>
-                      <v n="InputBoxDialogTitle">""</v>
-                      <v n="Password">false</v>
-                      <v n="UseTextOutputVariable">true</v>
-                      <v n="TextOutputVariableInitialized">true</v>
-                      <v n="OtherVarConversion">""</v>
-                      <v n="Format">""</v>
-                      <v n="DialogPosition" t="DialogPositionSetting">UseGlobalSetting</v>
-                      <v n="DialogXPos">""</v>
-                      <v n="DialogYPos">""</v>
-                    </o>
-                  </a>
-                </d>
+                <d n="VisualElementInputActions" t="Hashtable" />
                 <v n="VisualElementIdentification">{fd81410f-0685-490f-847c-53553dda32ac}</v>
                 <v n="VisualElementOwningObjectGuid">{b76d4b7c-f950-06ce-2833-75b1a7141b87}</v>
                 <a n="LMGuids" et="Guid" />
@@ -8697,8 +8678,8 @@
                       <v n="Id">2812299069L</v>
                       <l n="Value" t="ArrayList" cet="NamedStyleColor">
                         <o>
-                          <v n="Color">-1</v>
-                          <v n="CanonicalName">"White"</v>
+                          <v n="Color">-1381912</v>
+                          <v n="CanonicalName">"Element-Background-Color"</v>
                         </o>
                       </l>
                     </o>
@@ -8827,26 +8808,7 @@
                 <v n="VisualElementIdentifier">"GenElemInst_220"</v>
                 <n n="VisualElementOfflinePaintCommands" />
                 <n n="VisualElementFrameInformation" />
-                <d n="VisualElementInputActions" t="Hashtable" ckt="String" cvt="InputBoxInputAction[]">
-                  <v>OnMouseClick</v>
-                  <a cet="InputBoxInputAction">
-                    <o>
-                      <v n="InputBoxVariable">""</v>
-                      <v n="InputType">"Default"</v>
-                      <v n="InputBoxMin">""</v>
-                      <v n="InputBoxMax">""</v>
-                      <v n="InputBoxDialogTitle">""</v>
-                      <v n="Password">false</v>
-                      <v n="UseTextOutputVariable">true</v>
-                      <v n="TextOutputVariableInitialized">true</v>
-                      <v n="OtherVarConversion">""</v>
-                      <v n="Format">""</v>
-                      <v n="DialogPosition" t="DialogPositionSetting">UseGlobalSetting</v>
-                      <v n="DialogXPos">""</v>
-                      <v n="DialogYPos">""</v>
-                    </o>
-                  </a>
-                </d>
+                <d n="VisualElementInputActions" t="Hashtable" />
                 <v n="VisualElementIdentification">{5e945e8a-4124-482a-abcf-3ec14a38423c}</v>
                 <v n="VisualElementOwningObjectGuid">{b76d4b7c-f950-06ce-2833-75b1a7141b87}</v>
                 <a n="LMGuids" et="Guid" />


### PR DESCRIPTION
Adding selection of the pneumatic group (we have two pneumatic groups in the pneumatic box), to be able to assign correct pressure sensor value to the pneumatic axis.

How to test:
In the ST_PneumaticAxisConfig, select the correct Pneumatic Axis group with eSelectPneumaticAxisGroup.
Link the input variables gvl.nAirPressureSensorGroup1 and gvl.nAirPressureSensorGroup2 to analog input terminal EL3174-0002.
Define the low and high pressure values, in bar, in the gvl.fLowLimitAirPressureGroup1 and gvl.fLowLimitAirPressureGroup1 (or Group2 for pneumatic axes group 2).
In PneumaticVisu, the change of the air pressure limits is disabled, and these are now read-only values.
