### PR TITLE
MBP-118: External Brake control and airpad functionality

### DIFF
--- a/DUTs/Axis_Structures/ST_AirpadBrakeConfig.TcDUT
+++ b/DUTs/Axis_Structures/ST_AirpadBrakeConfig.TcDUT
@@ -4,6 +4,7 @@
     <Declaration><![CDATA[TYPE ST_AirpadBrakeConfig :
 STRUCT
     eAirpadBrake: E_AirpadBrake;
+    bFeedbackConnected: BOOL := FALSE; // If feedback signal used for pressurized airpad or opened brake
     tBrakeOpenDelayTime: TIME := T#0.1S; // Brake only
     tBrakeCloseAheadTime: TIME := T#0.1S; // Brake only
 END_STRUCT

--- a/DUTs/Axis_Structures/ST_AirpadBrakeConfig.TcDUT
+++ b/DUTs/Axis_Structures/ST_AirpadBrakeConfig.TcDUT
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <DUT Name="ST_AirpadBrakeConfig" Id="{6e69cb4e-eda2-07f7-262c-b7dcc5182c8c}">
+    <Declaration><![CDATA[TYPE ST_AirpadBrakeConfig :
+STRUCT
+    eAirpadBrake: E_AirpadBrake;
+    tBrakeOpenDelayTime: TIME := T#0.1S; // Brake only
+    tBrakeCloseAheadTime: TIME := T#0.1S; // Brake only
+END_STRUCT
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/DUTs/Axis_Structures/ST_AxisConfig.TcDUT
+++ b/DUTs/Axis_Structures/ST_AxisConfig.TcDUT
@@ -30,9 +30,7 @@ STRUCT
     fTempScalingFactor: REAL := 10.0; //Scaling factor for temperature readings
 
     // Use external brake
-    bExternalBrake: BOOL := FALSE;
-    tBrakeOpenDelayTime: TIME := T#0.1S;
-    tBrakeCloseAheadTime: TIME := T#0.1S;
+    stAirpadBrake: ST_AirpadBrakeConfig;
 
     //Read and Write parameters
     eAxisParameters: E_AxisParameters; //Enumeration of axis parameters for read/write operations

--- a/DUTs/Axis_Structures/ST_AxisConfig.TcDUT
+++ b/DUTs/Axis_Structures/ST_AxisConfig.TcDUT
@@ -13,7 +13,7 @@ STRUCT
     fHomeFinishDistance: LREAL := 0; //Distance to move back into the working zone after homing is complete
     eHomeSeq: E_HomingRoutines; //Homing sequence routine to execute
     eRestorePosition: E_RestorePosition; //Option to restore incremental axis position after power loss(0 = No, 1 = Yes)
-    bEnableStopWithAnyLimitSwitch :BOOL := TRUE; //Option to stop the axis when either the forward or backward limit switch is triggered
+    bEnableStopWithAnyLimitSwitch: BOOL := TRUE; //Option to stop the axis when either the forward or backward limit switch is triggered
 
     //Advanced homing parameters
     stHomingConfig: ST_HomingConfig; //Configuration for advanced homing routines
@@ -28,6 +28,11 @@ STRUCT
     bEnableTemperatureDisable: BOOL := FALSE; //Enable axis disabling due to high temperature
     fMaxTemperature: LREAL := 0.0; //Maximum temperature allowed before disabling
     fTempScalingFactor: REAL := 10.0; //Scaling factor for temperature readings
+
+    // Use external brake
+    bExternalBrake: BOOL := FALSE;
+    tBrakeOpenDelayTime: TIME := T#0.1S;
+    tBrakeCloseAheadTime: TIME := T#0.1S;
 
     //Read and Write parameters
     eAxisParameters: E_AxisParameters; //Enumeration of axis parameters for read/write operations

--- a/DUTs/Axis_Structures/ST_AxisControl.TcDUT
+++ b/DUTs/Axis_Structures/ST_AxisControl.TcDUT
@@ -21,7 +21,7 @@ STRUCT
     fPosition: LREAL; //Target position for absolute moves or distance for relative moves
     bHWMaskActive: BOOL := FALSE; //Indicates if hardware masking is active
     fMaskedTemperature: LREAL := 0.0; //Temperature value used when the hardware masking is active
-
+    bAirpadOnBrakeOpen AT %Q*: BOOL; //Output from method controlling airpad or brake (mutually exclusive)
 END_STRUCT
 END_TYPE
 ]]></Declaration>

--- a/DUTs/Axis_Structures/ST_AxisInputs.TcDUT
+++ b/DUTs/Axis_Structures/ST_AxisInputs.TcDUT
@@ -7,6 +7,7 @@ STRUCT
     bLimitBwd AT %I*: BOOL; //Backward limit switch input (indicates backward movement limit reached)
     bHomeSensor AT %I*: BOOL; //Home sensor input (reference signal for homing operation)
     nTempPT100 AT %I*: INT; //Temperature sensor input
+    bAirpadBrakeReady AT %I*: BOOL; //Airpad pressurized or external brake opened
 END_STRUCT
 END_TYPE
 ]]></Declaration>

--- a/DUTs/Axis_Structures/ST_AxisStatus.TcDUT
+++ b/DUTs/Axis_Structures/ST_AxisStatus.TcDUT
@@ -35,6 +35,7 @@ STRUCT
     fActVelocity: LREAL; //Current Velocity of the Axis
     bError: BOOL; //True if the axis is in an NC Error Stop state from Axis_Status
     nErrorID: UDINT; //ID of the last error from a motion function block or NC
+    eInternalMotion: E_MotionFunctions;
 END_STRUCT
 END_TYPE
 ]]></Declaration>

--- a/DUTs/E_AirpadBrake.TcDUT
+++ b/DUTs/E_AirpadBrake.TcDUT
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <DUT Name="E_AirpadBrake" Id="{6960b210-0ca5-0601-1372-7c299d82f9b8}">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+{attribute 'strict'}
+TYPE E_AirpadBrake :
+(
+    eStandard := 0,
+    eAirpad := 1,
+    eExternalBrake := 2
+):=eStandard;
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/DUTs/E_ExternalBrake.TcTLEO
+++ b/DUTs/E_ExternalBrake.TcTLEO
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <EnumerationTextList Name="E_ExternalBrake" Id="{3b0ef411-d8a7-0ec7-258f-652b9a44dc44}">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+{attribute 'strict'}
+TYPE E_ExternalBrake :
+(
+    BRAKE_CLOSED := 0,
+    BRAKE_OPENING := 1,
+    BRAKE_OPEN := 2,
+    BRAKE_CLOSING := 3
+);
+END_TYPE
+]]></Declaration>
+    <XmlArchive>
+      <Data>
+        <o xml:space="preserve" t="TextListEnumerationTextListObject">
+          <l n="TextList" t="ArrayList" cet="TextListRow">
+            <o>
+              <v n="TextID">"BRAKE_CLOSED"</v>
+              <v n="TextDefault">"0"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"BRAKE_OPENING"</v>
+              <v n="TextDefault">"1"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"BRAKE_OPEN"</v>
+              <v n="TextDefault">"2"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">"BRAKE_CLOSING"</v>
+              <v n="TextDefault">"3"</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+            <o>
+              <v n="TextID">""</v>
+              <v n="TextDefault">""</v>
+              <l n="LanguageTexts" t="ArrayList" />
+            </o>
+          </l>
+          <l n="Languages" t="ArrayList" />
+          <v n="GuidInit">{81211ebd-dd77-4b53-ae23-4c59fa3d421a}</v>
+          <v n="GuidReInit">{33d7ce5b-824b-4c0f-b6f2-323fdc8c7d02}</v>
+          <v n="GuidExitX">{748792ec-b84e-45b6-b633-3eafa7aa1235}</v>
+        </o>
+      </Data>
+      <TypeList>
+        <Type n="ArrayList">System.Collections.ArrayList</Type>
+        <Type n="Guid">System.Guid</Type>
+        <Type n="String">System.String</Type>
+        <Type n="TextListEnumerationTextListObject">{4b60233c-f940-4beb-b331-82133b520151}</Type>
+        <Type n="TextListRow">{53da1be7-ad25-47c3-b0e8-e26286dad2e0}</Type>
+      </TypeList>
+    </XmlArchive>
+  </EnumerationTextList>
+</TcPlcObject>

--- a/DUTs/E_ExternalBrake.TcTLEO
+++ b/DUTs/E_ExternalBrake.TcTLEO
@@ -6,9 +6,9 @@
 TYPE E_ExternalBrake :
 (
     BRAKE_CLOSED := 0,
-    BRAKE_OPENING := 1,
-    BRAKE_OPEN := 2,
-    BRAKE_CLOSING := 3
+    BRAKE_DELAY_OPENING := 1,
+    BRAKE_OPENED := 2,
+    BRAKE_CLOSE_DELAY_AMPLIFIER := 3
 );
 END_TYPE
 ]]></Declaration>
@@ -22,17 +22,17 @@ END_TYPE
               <l n="LanguageTexts" t="ArrayList" />
             </o>
             <o>
-              <v n="TextID">"BRAKE_OPENING"</v>
+              <v n="TextID">"BRAKE_DELAY_OPENING"</v>
               <v n="TextDefault">"1"</v>
               <l n="LanguageTexts" t="ArrayList" />
             </o>
             <o>
-              <v n="TextID">"BRAKE_OPEN"</v>
+              <v n="TextID">"BRAKE_OPENED"</v>
               <v n="TextDefault">"2"</v>
               <l n="LanguageTexts" t="ArrayList" />
             </o>
             <o>
-              <v n="TextID">"BRAKE_CLOSING"</v>
+              <v n="TextID">"BRAKE_CLOSE_DELAY_AMPLIFIER"</v>
               <v n="TextDefault">"3"</v>
               <l n="LanguageTexts" t="ArrayList" />
             </o>

--- a/DUTs/E_MotionFunctions.TcDUT
+++ b/DUTs/E_MotionFunctions.TcDUT
@@ -15,7 +15,8 @@ TYPE E_MotionFunctions :
     eWriteParameter := 50, //Writes the set value to the set parameter once bExecute goes high
     eReadParameter := 60, //Reads a single Parameter
     eWriteCoEParameters := 51, //Writes the set of values to the CoE once bExecute goes high
-    eReadCoEParameters := 61 //Reads the set of values from the CoE once bExecute goes high
+    eReadCoEParameters := 61, //Reads the set of values from the CoE once bExecute goes high
+    eWaitingOnCommand := 100
 ) := eHome; //Home is the default behaviour of the axis.
 END_TYPE
 ]]></Declaration>

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -216,6 +216,54 @@ _stAxis.stStatus.bBacklashCompensating := fbBacklashCompensation.Limiting;
 ]]></ST>
       </Implementation>
     </Method>
+    <Method Name="mControl_CommandHandler" Id="{e4d415b3-33e2-0dab-1c34-04ed19023ade}" FolderPath="Control Methods\">
+      <Declaration><![CDATA[METHOD mControl_CommandHandler
+VAR_INPUT
+    bPermit: BOOL := FALSE;
+    bPermitRequired: BOOL := FALSE;
+END_VAR
+
+VAR_INST
+    bExecuteCmdHandler: BOOL := FALSE;
+    RTRIG_Execute: R_TRIG;
+    bWaitingForMovePermit: BOOL := FALSE;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[RTRIG_Execute(CLK := _stAxis.stControl.bExecute);
+IF RTRIG_Execute.Q THEN
+    bExecuteCmdHandler := TRUE;
+END_IF
+
+// Abort this with some timeout or something related to bEnable?
+IF bExecuteCmdHandler THEN
+    CASE _stAxis.stControl.eCommand OF
+        E_MotionFunctions.eMoveAbsolute,
+        E_MotionFunctions.eMoveRelative,
+        E_MotionFunctions.eMoveVelocity,
+        E_MotionFunctions.eMoveModulo,
+        E_MotionFunctions.eGearInMultiMaster,
+        E_MotionFunctions.eGearOut,
+        E_MotionFunctions.eHome :
+            IF (bExecuteCmdHandler AND bPermit)
+                OR (NOT bExecuteCmdHandler) THEN
+                _stAxis.stStatus.eInternalMotion := _stAxis.stControl.eCommand;
+                bInternalExecute := TRUE;
+                bExecuteCmdHandler := FALSE;
+                bWaitingForMovePermit := FALSE;
+            ELSE
+                bWaitingForMovePermit := TRUE;
+            END_IF
+        E_MotionFunctions.eWriteParameter,
+        E_MotionFunctions.eReadParameter,
+        E_MotionFunctions.eReadCoEParameters,
+        E_MotionFunctions.eWriteCoEParameters:
+            bExecuteCmdHandler := FALSE;
+    END_CASE
+END_IF
+]]></ST>
+      </Implementation>
+    </Method>
     <Method Name="mControl_ExternalBrake" Id="{18ae79d4-85f5-0b8b-295a-ce90fc10f203}" FolderPath="Control Methods\">
       <Declaration><![CDATA[METHOD mControl_ExternalBrake: BOOL
 
@@ -1482,6 +1530,11 @@ stMcStatusReadWriteCoE := mParameters_ReadWriteCoE();
 
 mControl_LimitHitTimer();
 mControl_LimitLinking();
+mControl_CommandHandler(
+    bPermit := bLocalEnabled,
+    bPermitRequired :=
+        _stAxis.stConfig.stAirpadBrake.eAirpadBrake = E_AirpadBrake.eAirpad
+        OR _stAxis.stConfig.stAirpadBrake.eAirpadBrake = E_AirpadBrake.eExternalBrake);
 stMcStatusPower := mControl_Power();
 
 stMcStatusHalt := mMove_Halt();

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -104,13 +104,11 @@ VAR
     fbModMovDyn2RiseEdge: R_TRIG;
 
     eExternalBrake: E_ExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
-    bBrakeDisengage: BOOL := FALSE;
     bBrakeOutputCmd: BOOL := FALSE;
     bEnableCmdOld: BOOL := FALSE;
     bLocalEnabled: BOOL := FALSE;
     bEnabledOld: BOOL := FALSE;
     bEnableAmpCmd: BOOL := FALSE;
-    bEnableAmpCmdOld: BOOL := FALSE;
 
 END_VAR
 VAR CONSTANT
@@ -134,7 +132,6 @@ END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[bEnabledOld := _stAxis.stStatus.bEnabled;
-bEnableAmpCmdOld := bEnableAmpCmd;
 bEnableCmdOld := _stAxis.stControl.bEnable;
 
 _stAxis.stControl.bExecute := FALSE;
@@ -210,10 +207,10 @@ _stAxis.stStatus.bBacklashCompensating := fbBacklashCompensation.Limiting;
       </Implementation>
     </Method>
     <Method Name="mControl_ExternalBrake" Id="{18ae79d4-85f5-0b8b-295a-ce90fc10f203}" FolderPath="Control Methods\">
-      <Declaration><![CDATA[METHOD mControl_ExternalBrake
+      <Declaration><![CDATA[METHOD mControl_ExternalBrake: BOOL
 
 VAR_INST
-    nBrakeCounter: UINT := 0;
+    bEnableAmp: BOOL := FALSE;
     TON_BrakeDelayOn: TON;
     TON_BrakeDelayClosing: TON;
     tTimeCounterStart: TIME;
@@ -227,7 +224,8 @@ END_VAR
     tTimeCounterEnd := TIME();
 END_IF
 
-IF NOT _stAxis.stControl.bEnable AND bEnableCmdOld THEN
+IF (NOT _stAxis.stControl.bEnable OR _stAxis.stStatus.bError)
+    AND bEnableCmdOld THEN
     eExternalBrake := E_ExternalBrake.BRAKE_CLOSING;
     tTimeCounterStart := TIME();
     tTimeCounterEnd := TIME();
@@ -244,19 +242,19 @@ CASE eExternalBrake OF
         bBrakeOutputCmd := FALSE;;
         tTimeCounterStart := T#0S;
         tTimeCounterEnd := T#0S;
-        bEnableAmpCmd := FALSE;
+        bEnableAmp := FALSE;
 
 
     E_ExternalBrake.BRAKE_OPENING:
         // Postpone opening of brake
-        bEnableAmpCmd := TRUE;
+        bEnableAmp := TRUE;
 
         IF TON_BrakeDelayOn.Q THEN
-            IF NOT _stAxis.stStatus.bEnabled THEN
+            IF NOT _stAxis.stStatus.bEnabled OR _stAxis.stStatus.bError THEN
                 _stAxis.stControl.bEnable := FALSE;
                 bBrakeOutputCmd := FALSE;
                 tTimeCounterEnd := T#0S;
-                bEnableAmpCmd := FALSE;
+                bEnableAmp := FALSE;
                 bEnableCmdOld := FALSE; // to not trigger ECMC_BRAKE_CLOSING
                 eExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
             ELSE
@@ -266,9 +264,10 @@ CASE eExternalBrake OF
         END_IF
 
         // If enabled lost while opening, go directly to closed
-        IF bEnabledOld AND NOT _stAxis.stStatus.bEnabled THEN
+        IF bEnabledOld
+            AND (NOT _stAxis.stStatus.bEnabled OR _stAxis.stStatus.bError) THEN
             eExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
-            bEnableAmpCmd := FALSE;
+            bEnableAmp := FALSE;
             bBrakeOutputCmd := FALSE;
         END_IF
 
@@ -280,34 +279,41 @@ CASE eExternalBrake OF
 
     E_ExternalBrake.BRAKE_OPEN:
         // If enabled lost while opening, go directly to closed
-        IF NOT _stAxis.stStatus.bEnabled AND _stAxis.stControl.bEnable THEN
+        IF (NOT _stAxis.stStatus.bEnabled OR _stAxis.stStatus.bError)
+            AND _stAxis.stControl.bEnable THEN
             bBrakeOutputCmd := FALSE;
             tTimeCounterEnd := T#0S;
-            bEnableAmpCmd := FALSE;
+            bEnableAmp := FALSE;
             bEnableCmdOld := FALSE;
             eExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
         ELSE
             bBrakeOutputCmd := TRUE;
             tTimeCounterEnd := T#0S;
-            bEnableAmpCmd := TRUE;
+            bEnableAmp := TRUE;
         END_IF
 
-
+    // The check for bError in first rows of this function changes state to BRAKE_CLOSING.
+    // If bError TRUE we directly disable amplifier. Good?
+    // Might be good to also perform a check of the bSTOComing signal:
+    // * bStOComing -> wait for axis stopped -> BRAKE_CLOSING
+    // If STO comes before BRAKE_CLOSED -> the detection of bErrorStop should take us into BRAKE_CLOSED.
     E_ExternalBrake.BRAKE_CLOSING:
         // Postpone disabling of amplifier
         bBrakeOutputCmd := 0;
-        bEnableAmpCmd := TRUE;
-
+        bEnableAmp := TRUE;
         IF TON_BrakeDelayClosing.Q
-            OR NOT _stAxis.stStatus.bEnabled THEN
+            OR NOT _stAxis.stStatus.bEnabled
+            OR _stAxis.stStatus.bError THEN
             eExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
-            bEnableAmpCmd := FALSE;
+            bEnableAmp := FALSE;
             bBrakeOutputCmd := FALSE;
         END_IF
 
        tTimeCounterEnd := TIME();
 
 END_CASE
+
+mControl_ExternalBrake := bEnableAmp;
 ]]></ST>
       </Implementation>
     </Method>
@@ -484,7 +490,7 @@ END_VAR
 END_IF
 
 IF _stAxis.stConfig.bExternalBrake THEN
-    mControl_ExternalBrake();
+    bEnableAmpCmd := mControl_ExternalBrake();
 ELSE
     bEnableAmpCmd := _stAxis.stControl.bEnable;
 END_IF

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -1326,7 +1326,12 @@ _stAxis.stStatus.bMovingBackward := _stAxis.Axis.Status.NegativeDirection;
 _stAxis.stStatus.bInTargetPosition := _stAxis.Axis.Status.InTargetPosition;
 _stAxis.stStatus.bEnabled := NOT(_stAxis.Axis.Status.Disabled);
 IF _stAxis.stConfig.stAirpadBrake.eAirpadBrake = E_AirpadBrake.eExternalBrake THEN
-    bLocalEnabled := NOT(_stAxis.Axis.Status.Disabled) AND _stAxis.stControl.bAirpadOnBrakeOpen;
+    bLocalEnabled :=
+        _stAxis.stStatus.bEnabled
+        AND _stAxis.stControl.bAirpadOnBrakeOpen
+        AND ((_stAxis.stConfig.stAirpadBrake.bFeedbackConnected
+            AND _stAxis.stInputs.bAirpadBrakeReady)
+        OR NOT _stAxis.stConfig.stAirpadBrake.bFeedbackConnected);
 ELSIF _stAxis.stConfig.stAirpadBrake.eAirpadBrake = E_AirpadBrake.eStandard THEN
     bLocalEnabled := _stAxis.stStatus.bEnabled;
 END_IF

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -245,8 +245,8 @@ IF bExecuteCmdHandler THEN
         E_MotionFunctions.eGearInMultiMaster,
         E_MotionFunctions.eGearOut,
         E_MotionFunctions.eHome :
-            IF (bExecuteCmdHandler AND bPermit)
-                OR (NOT bExecuteCmdHandler) THEN
+            IF (bPermitRequired AND bPermit)
+                OR (NOT bPermitRequired) THEN
                 _stAxis.stStatus.eInternalMotion := _stAxis.stControl.eCommand;
                 bInternalExecute := TRUE;
                 bExecuteCmdHandler := FALSE;

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -103,6 +103,15 @@ VAR
     fbModMovDyn1RiseEdge: R_TRIG;
     fbModMovDyn2RiseEdge: R_TRIG;
 
+    eExternalBrake: E_ExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
+    bBrakeDisengage: BOOL := FALSE;
+    bBrakeOutputCmd: BOOL := FALSE;
+    bEnableCmdOld: BOOL := FALSE;
+    bLocalEnabled: BOOL := FALSE;
+    bLocalEnabledOld: BOOL := FALSE;
+    bEnableAmpCmd: BOOL := FALSE;
+    bEnableAmpCmdOld: BOOL := FALSE;
+
 END_VAR
 VAR CONSTANT
     nRATIO_DENOMINATOR_DEFAULT: UINT := 1;
@@ -124,7 +133,10 @@ END_VAR
       <Declaration><![CDATA[METHOD EndOfCycle : BOOL
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
+        <ST><![CDATA[bLocalEnabledOld := _stAxis.stStatus.bEnabled;
+bEnableAmpCmdOld := bEnableAmpCmd;
+bEnableCmdOld := _stAxis.stControl.bEnable;
+
 _stAxis.stControl.bExecute := FALSE;
 ]]></ST>
       </Implementation>
@@ -194,6 +206,108 @@ END_IF
 mControl_BacklashCompensation.Error := fbBacklashCompensation.Error;
 mControl_BacklashCompensation.ErrorID := fbBacklashCompensation.ErrorID;
 _stAxis.stStatus.bBacklashCompensating := fbBacklashCompensation.Limiting;
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="mControl_ExternalBrake" Id="{18ae79d4-85f5-0b8b-295a-ce90fc10f203}" FolderPath="Control Methods\">
+      <Declaration><![CDATA[METHOD mControl_ExternalBrake
+
+VAR_INST
+    nBrakeCounter: UINT := 0;
+    TON_BrakeDelayOn: TON;
+    TON_BrakeDelayClosing: TON;
+    tTimeCounterStart: TIME;
+    tTimeCounterEnd: TIME;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[IF _stAxis.stControl.bEnable AND NOT bEnableCmdOld THEN
+    eExternalBrake := E_ExternalBrake.BRAKE_OPENING;
+    tTimeCounterStart := TIME();
+    tTimeCounterEnd := TIME();
+END_IF
+
+IF NOT _stAxis.stControl.bEnable AND bEnableCmdOld THEN
+    eExternalBrake := E_ExternalBrake.BRAKE_CLOSING;
+    tTimeCounterStart := TIME();
+    tTimeCounterEnd := TIME();
+END_IF
+
+TON_BrakeDelayOn(
+    IN := (tTimeCounterEnd-tTimeCounterStart) > _stAxis.stConfig.tBrakeOpenDelayTime);
+TON_BrakeDelayClosing(
+    IN := (tTimeCounterEnd-tTimeCounterStart) > _stAxis.stConfig.tBrakeCloseAheadTime);
+
+CASE eExternalBrake OF
+
+    E_ExternalBrake.BRAKE_CLOSED:
+        bBrakeOutputCmd := FALSE;;
+        tTimeCounterStart := T#0S;
+        tTimeCounterEnd := T#0S;
+        bEnableAmpCmd := FALSE;
+
+
+    E_ExternalBrake.BRAKE_OPENING:
+        // Postpone opening of brake
+        bEnableAmpCmd := TRUE;
+
+        IF TON_BrakeDelayOn.Q THEN
+            IF NOT bLocalEnabled THEN
+                _stAxis.stControl.bEnable := FALSE;
+                bBrakeOutputCmd := FALSE;
+                tTimeCounterEnd := T#0S;
+                bEnableAmpCmd := FALSE;
+                bEnableCmdOld := FALSE; // to not trigger ECMC_BRAKE_CLOSING
+                eExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
+            ELSE
+                eExternalBrake := E_ExternalBrake.BRAKE_OPEN;
+                bBrakeOutputCmd := TRUE;
+            END_IF
+        END_IF
+
+        // If enabled lost while opening, go directly to closed
+        IF bLocalEnabledOld AND NOT bLocalEnabled THEN
+            eExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
+            bEnableAmpCmd := FALSE;
+            bBrakeOutputCmd := FALSE;
+        END_IF
+
+        // Start counting when enabled
+        IF bLocalEnabled THEN
+            tTimeCounterEnd := TIME();
+        END_IF
+
+
+    E_ExternalBrake.BRAKE_OPEN:
+        // If enabled lost while opening, go directly to closed
+        IF NOT bLocalEnabled AND _stAxis.stControl.bEnable THEN
+            bBrakeOutputCmd := FALSE;
+            tTimeCounterEnd := T#0S;
+            bEnableAmpCmd := FALSE;
+            bEnableCmdOld := FALSE;
+            eExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
+        ELSE
+            bBrakeOutputCmd := TRUE;
+            tTimeCounterEnd := T#0S;
+            bEnableAmpCmd := TRUE;
+        END_IF
+
+
+    E_ExternalBrake.BRAKE_CLOSING:
+        // Postpone disabling of amplifier
+        bBrakeOutputCmd := 0;
+        bEnableAmpCmd := TRUE;
+
+        IF TON_BrakeDelayClosing.Q
+            OR NOT bLocalEnabled THEN
+            eExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
+            bEnableAmpCmd := FALSE;
+            bBrakeOutputCmd := FALSE;
+        END_IF
+
+       tTimeCounterEnd := TIME();
+
+END_CASE
 ]]></ST>
       </Implementation>
     </Method>
@@ -369,7 +483,13 @@ END_VAR
     _stAxis.stControl.bEnable:= FALSE;
 END_IF
 
-fbPower.Enable := _stAxis.stControl.bEnable;
+IF _stAxis.stConfig.bExternalBrake THEN
+    mControl_ExternalBrake();
+ELSE
+    bEnableAmpCmd := _stAxis.stControl.bEnable;
+END_IF
+
+fbPower.Enable := bEnableAmpCmd;
 
 fbPower.Enable_Negative := (_stAxis.stStatus.bBwEnabled OR bWaitForStopAfterLimitHit) AND NOT _stAxis.stStatus.bInterlockedBwd;
 fbPower.Enable_Positive := (_stAxis.stStatus.bFwEnabled OR bWaitForStopAfterLimitHit) AND NOT _stAxis.stStatus.bInterlockedFwd;
@@ -553,7 +673,8 @@ END_IF
       <Declaration><![CDATA[METHOD mMove_MoveAbsolute : ST_McStatus
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF _stAxis.stControl.eCommand = E_MotionFunctions.eMoveAbsolute THEN
+        <ST><![CDATA[IF _stAxis.stControl.eCommand = E_MotionFunctions.eMoveAbsolute
+    AND _stAxis.stStatus.bEnabled THEN
     fbMoveAbsolute.Execute := _stAxis.stControl.bExecute;
     IF fbMoveAbsolute.Execute AND fbMoveAbsolute.Busy THEN
         fbMoveAbsolute2.Execute := TRUE;
@@ -1135,7 +1256,12 @@ _stAxis.stStatus.fActVelocity := _stAxis.Axis.NcToPlc.ActVelo;
 _stAxis.stStatus.bMovingForward := _stAxis.Axis.Status.PositiveDirection;
 _stAxis.stStatus.bMovingBackward := _stAxis.Axis.Status.NegativeDirection;
 _stAxis.stStatus.bInTargetPosition := _stAxis.Axis.Status.InTargetPosition;
-_stAxis.stStatus.bEnabled := NOT(_stAxis.Axis.Status.Disabled);
+bLocalEnabled := NOT(_stAxis.Axis.Status.Disabled);
+IF _stAxis.stConfig.bExternalBrake THEN
+    _stAxis.stStatus.bEnabled := NOT(_stAxis.Axis.Status.Disabled) AND bBrakeOutputCmd;
+ELSE
+    _stAxis.stStatus.bEnabled := NOT(_stAxis.Axis.Status.Disabled);
+END_IF
 _stAxis.stError.nNCErrorID := _stAxis.Axis.Status.ErrorID;
 ]]></ST>
       </Implementation>

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -744,8 +744,8 @@ END_IF
       <Declaration><![CDATA[METHOD mMove_MoveAbsolute : ST_McStatus
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF _stAxis.stControl.eCommand = E_MotionFunctions.eMoveAbsolute THEN
-    fbMoveAbsolute.Execute := _stAxis.stControl.bExecute;
+        <ST><![CDATA[IF _stAxis.stStatus.eInternalMotion = E_MotionFunctions.eMoveAbsolute THEN
+    fbMoveAbsolute.Execute := bInternalExecute;
     IF fbMoveAbsolute.Execute AND fbMoveAbsolute.Busy THEN
         fbMoveAbsolute2.Execute := TRUE;
     END_IF
@@ -854,9 +854,8 @@ END_IF
       <Declaration><![CDATA[METHOD mMove_MoveRelative : ST_McStatus
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-IF _stAxis.stControl.eCommand = E_MotionFunctions.eMoveRelative THEN
-    fbMoveRelative.Execute := _stAxis.stControl.bExecute;
+        <ST><![CDATA[IF _stAxis.stStatus.eInternalMotion = E_MotionFunctions.eMoveRelative THEN
+    fbMoveRelative.Execute := bInternalExecute;
 END_IF
 
 fbMoveRelative.Distance := _stAxis.stControl.fPosition;
@@ -1311,8 +1310,7 @@ END_IF
       <Declaration><![CDATA[METHOD mStatus_AxisStatus : BOOL
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-_stAxis.Axis.ReadStatus();
+        <ST><![CDATA[_stAxis.Axis.ReadStatus();
 IF _stAxis.Axis.Status.OpMode.Modulo THEN
     _stAxis.stStatus.fActPosition := _stAxis.Axis.NcToPlc.ModuloActPos;
 ELSE
@@ -1520,8 +1518,7 @@ END_IF
       <Declaration><![CDATA[METHOD Run : BOOL
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-mStatus_AxisStatus();
+        <ST><![CDATA[mStatus_AxisStatus();
 mParameters_ReadNc();
 mParameters_Init();
 stMcStatusReadParameter := mParameters_ReadParameter();

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -108,7 +108,7 @@ VAR
     bBrakeOutputCmd: BOOL := FALSE;
     bEnableCmdOld: BOOL := FALSE;
     bLocalEnabled: BOOL := FALSE;
-    bLocalEnabledOld: BOOL := FALSE;
+    bEnabledOld: BOOL := FALSE;
     bEnableAmpCmd: BOOL := FALSE;
     bEnableAmpCmdOld: BOOL := FALSE;
 
@@ -133,7 +133,7 @@ END_VAR
       <Declaration><![CDATA[METHOD EndOfCycle : BOOL
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[bLocalEnabledOld := _stAxis.stStatus.bEnabled;
+        <ST><![CDATA[bEnabledOld := _stAxis.stStatus.bEnabled;
 bEnableAmpCmdOld := bEnableAmpCmd;
 bEnableCmdOld := _stAxis.stControl.bEnable;
 
@@ -252,7 +252,7 @@ CASE eExternalBrake OF
         bEnableAmpCmd := TRUE;
 
         IF TON_BrakeDelayOn.Q THEN
-            IF NOT bLocalEnabled THEN
+            IF NOT _stAxis.stStatus.bEnabled THEN
                 _stAxis.stControl.bEnable := FALSE;
                 bBrakeOutputCmd := FALSE;
                 tTimeCounterEnd := T#0S;
@@ -266,21 +266,21 @@ CASE eExternalBrake OF
         END_IF
 
         // If enabled lost while opening, go directly to closed
-        IF bLocalEnabledOld AND NOT bLocalEnabled THEN
+        IF bEnabledOld AND NOT _stAxis.stStatus.bEnabled THEN
             eExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
             bEnableAmpCmd := FALSE;
             bBrakeOutputCmd := FALSE;
         END_IF
 
         // Start counting when enabled
-        IF bLocalEnabled THEN
+        IF _stAxis.stStatus.bEnabled THEN
             tTimeCounterEnd := TIME();
         END_IF
 
 
     E_ExternalBrake.BRAKE_OPEN:
         // If enabled lost while opening, go directly to closed
-        IF NOT bLocalEnabled AND _stAxis.stControl.bEnable THEN
+        IF NOT _stAxis.stStatus.bEnabled AND _stAxis.stControl.bEnable THEN
             bBrakeOutputCmd := FALSE;
             tTimeCounterEnd := T#0S;
             bEnableAmpCmd := FALSE;
@@ -299,7 +299,7 @@ CASE eExternalBrake OF
         bEnableAmpCmd := TRUE;
 
         IF TON_BrakeDelayClosing.Q
-            OR NOT bLocalEnabled THEN
+            OR NOT _stAxis.stStatus.bEnabled THEN
             eExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
             bEnableAmpCmd := FALSE;
             bBrakeOutputCmd := FALSE;
@@ -491,8 +491,14 @@ END_IF
 
 fbPower.Enable := bEnableAmpCmd;
 
-fbPower.Enable_Negative := (_stAxis.stStatus.bBwEnabled OR bWaitForStopAfterLimitHit) AND NOT _stAxis.stStatus.bInterlockedBwd;
-fbPower.Enable_Positive := (_stAxis.stStatus.bFwEnabled OR bWaitForStopAfterLimitHit) AND NOT _stAxis.stStatus.bInterlockedFwd;
+fbPower.Enable_Negative :=
+    (_stAxis.stStatus.bBwEnabled OR bWaitForStopAfterLimitHit)
+    AND NOT _stAxis.stStatus.bInterlockedBwd
+    AND bLocalEnabled;
+fbPower.Enable_Positive :=
+    (_stAxis.stStatus.bFwEnabled OR bWaitForStopAfterLimitHit)
+    AND NOT _stAxis.stStatus.bInterlockedFwd
+    AND bLocalEnabled;
 fbPower.Override := _stAxis.stConfig.fOverride;
 
 fbPower(Axis := _stAxis.Axis);
@@ -673,8 +679,7 @@ END_IF
       <Declaration><![CDATA[METHOD mMove_MoveAbsolute : ST_McStatus
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF _stAxis.stControl.eCommand = E_MotionFunctions.eMoveAbsolute
-    AND _stAxis.stStatus.bEnabled THEN
+        <ST><![CDATA[IF _stAxis.stControl.eCommand = E_MotionFunctions.eMoveAbsolute THEN
     fbMoveAbsolute.Execute := _stAxis.stControl.bExecute;
     IF fbMoveAbsolute.Execute AND fbMoveAbsolute.Busy THEN
         fbMoveAbsolute2.Execute := TRUE;
@@ -1256,12 +1261,13 @@ _stAxis.stStatus.fActVelocity := _stAxis.Axis.NcToPlc.ActVelo;
 _stAxis.stStatus.bMovingForward := _stAxis.Axis.Status.PositiveDirection;
 _stAxis.stStatus.bMovingBackward := _stAxis.Axis.Status.NegativeDirection;
 _stAxis.stStatus.bInTargetPosition := _stAxis.Axis.Status.InTargetPosition;
-bLocalEnabled := NOT(_stAxis.Axis.Status.Disabled);
+_stAxis.stStatus.bEnabled := NOT(_stAxis.Axis.Status.Disabled);
 IF _stAxis.stConfig.bExternalBrake THEN
-    _stAxis.stStatus.bEnabled := NOT(_stAxis.Axis.Status.Disabled) AND bBrakeOutputCmd;
+    bLocalEnabled := NOT(_stAxis.Axis.Status.Disabled) AND bBrakeOutputCmd;
 ELSE
-    _stAxis.stStatus.bEnabled := NOT(_stAxis.Axis.Status.Disabled);
+    bLocalEnabled := _stAxis.stStatus.bEnabled;
 END_IF
+
 _stAxis.stError.nNCErrorID := _stAxis.Axis.Status.ErrorID;
 ]]></ST>
       </Implementation>

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -103,6 +103,7 @@ VAR
     fbModMovDyn1RiseEdge: R_TRIG;
     fbModMovDyn2RiseEdge: R_TRIG;
 
+    bInternalExecute: BOOL := FALSE;
     bEnableCmdOld: BOOL := FALSE;
     bLocalEnabled: BOOL := FALSE;
     bEnabledOld: BOOL := FALSE;
@@ -129,7 +130,18 @@ END_VAR
       <Declaration><![CDATA[METHOD EndOfCycle : BOOL
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[bEnabledOld := _stAxis.stStatus.bEnabled;
+        <ST><![CDATA[IF _stAxis.stStatus.bDone
+    OR _stAxis.stStatus.bError
+    OR _stAxis.Axis.Status.Error
+    OR _stAxis.Axis.Status.Disabled
+    OR _stAxis.Axis.Status.Stopping
+    OR _stAxis.stStatus.bCommandAborted
+    OR NOT _stAxis.stStatus.bMoving THEN
+    _stAxis.stStatus.eInternalMotion := E_MotionFunctions.eWaitingOnCommand;
+END_IF
+
+bInternalExecute := FALSE;
+bEnabledOld := _stAxis.stStatus.bEnabled;
 bEnableCmdOld := _stAxis.stControl.bEnable;
 
 _stAxis.stControl.bExecute := FALSE;

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -115,6 +115,7 @@ VAR CONSTANT
     nNO_GEARING: UINT := 0;
     nMCSTATUS_ARRAY_SIZE: UINT := 15;
     nMULTI_MASTER_MAX_AXES: UINT := 4;
+    tCOMMANDHANDLER_TIMEOUT: TIME := T#5s;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -227,6 +228,7 @@ VAR_INST
     bExecuteCmdHandler: BOOL := FALSE;
     RTRIG_Execute: R_TRIG;
     bWaitingForMovePermit: BOOL := FALSE;
+    TON_Timeout: TON;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -260,6 +262,14 @@ IF bExecuteCmdHandler THEN
         E_MotionFunctions.eWriteCoEParameters:
             bExecuteCmdHandler := FALSE;
     END_CASE
+END_IF
+
+TON_Timeout(IN := bWaitingForMovePermit, PT := tCOMMANDHANDLER_TIMEOUT);
+IF TON_Timeout.Q
+    OR _stAxis.stControl.bHalt
+    OR _stAxis.stControl.bStop THEN
+    bExecuteCmdHandler := FALSE;
+    bWaitingForMovePermit := FALSE;
 END_IF
 ]]></ST>
       </Implementation>

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -103,8 +103,6 @@ VAR
     fbModMovDyn1RiseEdge: R_TRIG;
     fbModMovDyn2RiseEdge: R_TRIG;
 
-    eExternalBrake: E_ExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
-    bBrakeOutputCmd: BOOL := FALSE;
     bEnableCmdOld: BOOL := FALSE;
     bLocalEnabled: BOOL := FALSE;
     bEnabledOld: BOOL := FALSE;
@@ -210,6 +208,7 @@ _stAxis.stStatus.bBacklashCompensating := fbBacklashCompensation.Limiting;
       <Declaration><![CDATA[METHOD mControl_ExternalBrake: BOOL
 
 VAR_INST
+    eExternalBrake: E_ExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
     bEnableAmp: BOOL := FALSE;
     TON_BrakeDelayOn: TON;
     TON_BrakeDelayClosing: TON;
@@ -232,14 +231,14 @@ IF (NOT _stAxis.stControl.bEnable OR _stAxis.stStatus.bError)
 END_IF
 
 TON_BrakeDelayOn(
-    IN := (tTimeCounterEnd-tTimeCounterStart) > _stAxis.stConfig.tBrakeOpenDelayTime);
+    IN := (tTimeCounterEnd-tTimeCounterStart) > _stAxis.stConfig.stAirpadBrake.tBrakeOpenDelayTime);
 TON_BrakeDelayClosing(
-    IN := (tTimeCounterEnd-tTimeCounterStart) > _stAxis.stConfig.tBrakeCloseAheadTime);
+    IN := (tTimeCounterEnd-tTimeCounterStart) > _stAxis.stConfig.stAirpadBrake.tBrakeCloseAheadTime);
 
 CASE eExternalBrake OF
 
     E_ExternalBrake.BRAKE_CLOSED:
-        bBrakeOutputCmd := FALSE;;
+        _stAxis.stControl.bAirpadOnBrakeOpen := FALSE;
         tTimeCounterStart := T#0S;
         tTimeCounterEnd := T#0S;
         bEnableAmp := FALSE;
@@ -252,14 +251,14 @@ CASE eExternalBrake OF
         IF TON_BrakeDelayOn.Q THEN
             IF NOT _stAxis.stStatus.bEnabled OR _stAxis.stStatus.bError THEN
                 _stAxis.stControl.bEnable := FALSE;
-                bBrakeOutputCmd := FALSE;
+                _stAxis.stControl.bAirpadOnBrakeOpen := FALSE;
                 tTimeCounterEnd := T#0S;
                 bEnableAmp := FALSE;
                 bEnableCmdOld := FALSE; // to not trigger BRAKE_CLOSE_DELAY_AMPLIFIER
                 eExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
             ELSE
                 eExternalBrake := E_ExternalBrake.BRAKE_OPENED;
-                bBrakeOutputCmd := TRUE;
+                _stAxis.stControl.bAirpadOnBrakeOpen := TRUE;
             END_IF
         END_IF
 
@@ -268,7 +267,7 @@ CASE eExternalBrake OF
             AND (NOT _stAxis.stStatus.bEnabled OR _stAxis.stStatus.bError) THEN
             eExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
             bEnableAmp := FALSE;
-            bBrakeOutputCmd := FALSE;
+            _stAxis.stControl.bAirpadOnBrakeOpen := FALSE;
         END_IF
 
         // Start counting when enabled
@@ -281,13 +280,13 @@ CASE eExternalBrake OF
         // If enabled lost while opening, go directly to closed
         IF (NOT _stAxis.stStatus.bEnabled OR _stAxis.stStatus.bError)
             AND _stAxis.stControl.bEnable THEN
-            bBrakeOutputCmd := FALSE;
+            _stAxis.stControl.bAirpadOnBrakeOpen := FALSE;
             tTimeCounterEnd := T#0S;
             bEnableAmp := FALSE;
             bEnableCmdOld := FALSE;
             eExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
         ELSE
-            bBrakeOutputCmd := TRUE;
+            _stAxis.stControl.bAirpadOnBrakeOpen := TRUE;
             tTimeCounterEnd := T#0S;
             bEnableAmp := TRUE;
         END_IF
@@ -299,14 +298,14 @@ CASE eExternalBrake OF
     // If STO comes before BRAKE_CLOSED -> the detection of bErrorStop should take us into BRAKE_CLOSED.
     E_ExternalBrake.BRAKE_CLOSE_DELAY_AMPLIFIER:
         // Postpone disabling of amplifier
-        bBrakeOutputCmd := 0;
+        _stAxis.stControl.bAirpadOnBrakeOpen := FALSE;
         bEnableAmp := TRUE;
         IF TON_BrakeDelayClosing.Q
             OR NOT _stAxis.stStatus.bEnabled
             OR _stAxis.stStatus.bError THEN
             eExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
             bEnableAmp := FALSE;
-            bBrakeOutputCmd := FALSE;
+            _stAxis.stControl.bAirpadOnBrakeOpen := FALSE;
         END_IF
 
        tTimeCounterEnd := TIME();
@@ -489,7 +488,7 @@ END_VAR
     _stAxis.stControl.bEnable:= FALSE;
 END_IF
 
-IF _stAxis.stConfig.bExternalBrake THEN
+IF _stAxis.stConfig.stAirpadBrake.eAirpadBrake = E_AirpadBrake.eExternalBrake THEN
     bEnableAmpCmd := mControl_ExternalBrake();
 ELSE
     bEnableAmpCmd := _stAxis.stControl.bEnable;
@@ -1268,9 +1267,9 @@ _stAxis.stStatus.bMovingForward := _stAxis.Axis.Status.PositiveDirection;
 _stAxis.stStatus.bMovingBackward := _stAxis.Axis.Status.NegativeDirection;
 _stAxis.stStatus.bInTargetPosition := _stAxis.Axis.Status.InTargetPosition;
 _stAxis.stStatus.bEnabled := NOT(_stAxis.Axis.Status.Disabled);
-IF _stAxis.stConfig.bExternalBrake THEN
-    bLocalEnabled := NOT(_stAxis.Axis.Status.Disabled) AND bBrakeOutputCmd;
-ELSE
+IF _stAxis.stConfig.stAirpadBrake.eAirpadBrake = E_AirpadBrake.eExternalBrake THEN
+    bLocalEnabled := NOT(_stAxis.Axis.Status.Disabled) AND _stAxis.stControl.bAirpadOnBrakeOpen;
+ELSIF _stAxis.stConfig.stAirpadBrake.eAirpadBrake = E_AirpadBrake.eStandard THEN
     bLocalEnabled := _stAxis.stStatus.bEnabled;
 END_IF
 

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -219,14 +219,14 @@ END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF _stAxis.stControl.bEnable AND NOT bEnableCmdOld THEN
-    eExternalBrake := E_ExternalBrake.BRAKE_OPENING;
+    eExternalBrake := E_ExternalBrake.BRAKE_DELAY_OPENING;
     tTimeCounterStart := TIME();
     tTimeCounterEnd := TIME();
 END_IF
 
 IF (NOT _stAxis.stControl.bEnable OR _stAxis.stStatus.bError)
     AND bEnableCmdOld THEN
-    eExternalBrake := E_ExternalBrake.BRAKE_CLOSING;
+    eExternalBrake := E_ExternalBrake.BRAKE_CLOSE_DELAY_AMPLIFIER;
     tTimeCounterStart := TIME();
     tTimeCounterEnd := TIME();
 END_IF
@@ -245,7 +245,7 @@ CASE eExternalBrake OF
         bEnableAmp := FALSE;
 
 
-    E_ExternalBrake.BRAKE_OPENING:
+    E_ExternalBrake.BRAKE_DELAY_OPENING:
         // Postpone opening of brake
         bEnableAmp := TRUE;
 
@@ -255,10 +255,10 @@ CASE eExternalBrake OF
                 bBrakeOutputCmd := FALSE;
                 tTimeCounterEnd := T#0S;
                 bEnableAmp := FALSE;
-                bEnableCmdOld := FALSE; // to not trigger ECMC_BRAKE_CLOSING
+                bEnableCmdOld := FALSE; // to not trigger BRAKE_CLOSE_DELAY_AMPLIFIER
                 eExternalBrake := E_ExternalBrake.BRAKE_CLOSED;
             ELSE
-                eExternalBrake := E_ExternalBrake.BRAKE_OPEN;
+                eExternalBrake := E_ExternalBrake.BRAKE_OPENED;
                 bBrakeOutputCmd := TRUE;
             END_IF
         END_IF
@@ -277,7 +277,7 @@ CASE eExternalBrake OF
         END_IF
 
 
-    E_ExternalBrake.BRAKE_OPEN:
+    E_ExternalBrake.BRAKE_OPENED:
         // If enabled lost while opening, go directly to closed
         IF (NOT _stAxis.stStatus.bEnabled OR _stAxis.stStatus.bError)
             AND _stAxis.stControl.bEnable THEN
@@ -292,12 +292,12 @@ CASE eExternalBrake OF
             bEnableAmp := TRUE;
         END_IF
 
-    // The check for bError in first rows of this function changes state to BRAKE_CLOSING.
+    // The check for bError in first rows of this function changes state to BRAKE_CLOSE_DELAY_AMPLIFIER.
     // If bError TRUE we directly disable amplifier. Good?
     // Might be good to also perform a check of the bSTOComing signal:
-    // * bStOComing -> wait for axis stopped -> BRAKE_CLOSING
+    // * bStOComing -> wait for axis stopped -> BRAKE_CLOSE_DELAY_AMPLIFIER
     // If STO comes before BRAKE_CLOSED -> the detection of bErrorStop should take us into BRAKE_CLOSED.
-    E_ExternalBrake.BRAKE_CLOSING:
+    E_ExternalBrake.BRAKE_CLOSE_DELAY_AMPLIFIER:
         // Postpone disabling of amplifier
         bBrakeOutputCmd := 0;
         bEnableAmp := TRUE;


### PR DESCRIPTION
Implement external brake control.
Enable airpad functionality.
Introduce a command handler level between the actual command and the motion functions to facilitate delaying commands in case of e.g. using brake control.