### PR TITLE
Kristinaj/update pressure limits variables

### DIFF
--- a/DUTs/Pneumatics/ST_PneumaticAxisConfig.TcDUT
+++ b/DUTs/Pneumatics/ST_PneumaticAxisConfig.TcDUT
@@ -3,7 +3,7 @@
   <DUT Name="ST_PneumaticAxisConfig" Id="{f7d3b15a-c25b-0a63-3175-d55d3daa4326}">
     <Declaration><![CDATA[TYPE ST_PneumaticAxisConfig :
 STRUCT
-    bPSSPneumaticAxisShutter: BOOL := FALSE; //Bit to define if pneumatic axis is Shutter needing PSS permit
+    bSafetyShutter: BOOL := FALSE; //Bit to define if pneumatic axis is Shutter needing PSS permit
     sPneumaticAxisName: String(32);
     nTimeToExtend: INT; //User defined time for the cylider to extract in seconds
     nTimeToRetract: INT; //User defined time for the cylinder to retract in seconds

--- a/GVLs/GVL.TcGVL
+++ b/GVLs/GVL.TcGVL
@@ -17,11 +17,6 @@
     bLocalMode: BOOL;
     nAirPressureSensorGroup1 AT %I*: INT; //Raw value from analog air pressure sensor for pneumatic axes group 1
     nAirPressureSensorGroup2 AT %I*: INT; //Raw value from analog air pressure sensor for pneumatic axes group 2
-    fLowLimitAirPressureGroup1: REAL; //User defined value in bar for low limit air pressure value for pneumatic axes group 1
-    fHighLimitAirPressureGroup1: REAL; //User defined value in bar for low limit air pressure value for pneumatic axes group 1
-    fLowLimitAirPressureGroup2: REAL; //User defined value in bar for low limit air pressure value for pneumatic axes group 2
-    fHighLimitAirPressureGroup2: REAL; //User defined value in bar for low limit air pressure value for pneumatic axes group 2
-
 END_VAR
 
 VAR_GLOBAL CONSTANT

--- a/POUs/Pneumatics/FB_PneumaticAxis.TcPOU
+++ b/POUs/Pneumatics/FB_PneumaticAxis.TcPOU
@@ -227,7 +227,7 @@ END_IF
 
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF _stPneumaticAxis.stPneumaticAxisConfig.bPSSPneumaticAxisShutter THEN
+        <ST><![CDATA[IF _stPneumaticAxis.stPneumaticAxisConfig.bSafetyShutter THEN
     _stPneumaticAxis.stPneumaticAxisControl.bInterlock := FALSE;
     ELSIF _stPneumaticAxis.stPneumaticAxisControl.bInterlock THEN
     _stPneumaticAxis.stPneumaticAxisStatus.sStatus := 'WARNING: INTERLOCK ON, CAN NOT MOVE';
@@ -252,7 +252,7 @@ END_IF
 
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF NOT _stPneumaticAxis.stPneumaticAxisConfig.bPSSPneumaticAxisShutter THEN
+        <ST><![CDATA[IF NOT _stPneumaticAxis.stPneumaticAxisConfig.bSafetyShutter THEN
     _stPneumaticAxis.stPneumaticAxisInputs.bPSSPermit := FALSE;
 ELSIF NOT _stPneumaticAxis.stPneumaticAxisInputs.bPSSPermit THEN
     _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eNoPSSPermit;
@@ -562,13 +562,13 @@ mScaledPressureValue:= rGradient * nRawValue + rOffset;
 
         E_PneumaticAxisGroup.ePneumaticAxisGroup1:
         _stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw := nAirPressureSensorGroup1;
-        _stPneumaticAxis.stPneumaticAxisConfig.fLowLimitPressureValue := fLowLimitAirPressureGroup1;
-        _stPneumaticAxis.stPneumaticAxisConfig.fHighLimitPressureValue := fHighLimitAirPressureGroup1;
+        _stPneumaticAxis.stPneumaticAxisConfig.fLowLimitPressureValue := GVL_APP.fLOW_LIMIT_AIR_PRESSURE1;
+        _stPneumaticAxis.stPneumaticAxisConfig.fHighLimitPressureValue := GVL_APP.fHIGH_LIMIT_AIR_PRESSURE1;
 
         E_PneumaticAxisGroup.ePneumaticAxisGroup2:
         _stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw := nAirPressureSensorGroup2;
-        _stPneumaticAxis.stPneumaticAxisConfig.fLowLimitPressureValue := fLowLimitAirPressureGroup2;
-        _stPneumaticAxis.stPneumaticAxisConfig.fHighLimitPressureValue := fHighLimitAirPressureGroup2;
+        _stPneumaticAxis.stPneumaticAxisConfig.fLowLimitPressureValue := GVL_APP.fLOW_LIMIT_AIR_PRESSURE2;
+        _stPneumaticAxis.stPneumaticAxisConfig.fHighLimitPressureValue := GVL_APP.fHIGH_LIMIT_AIR_PRESSURE2;
     END_CASE
 
 _stPneumaticAxis.stPneumaticAxisInputs.fPressureValueScaled := mScaledPressureValue(nRawValue :=  _stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw, fRawHigh := 30518, fRawLow :=0, fScaledHigh := 10, fScaledLow := 0 );


### PR DESCRIPTION
Things that are updated:
- Renamed the variable that says that the pneumatic axis is type shutter : bSafetyShutter in stPneumaticaAxisConfig
- Removed the pressure limits from GVLs (they are now in GVL_APP)
- Updated method to assign the pressure group to axis