### PR TITLE
Mbp 310 changes for pneumatics

### DIFF
--- a/DUTs/Pneumatics/ST_PneumaticAxisConfig.TcDUT
+++ b/DUTs/Pneumatics/ST_PneumaticAxisConfig.TcDUT
@@ -8,7 +8,6 @@ STRUCT
     nTimeToExtend: INT; //User defined time for the cylider to extract in seconds
     nTimeToRetract: INT; //User defined time for the cylinder to retract in seconds
     eSelectPneumaticAxisGroup: E_PneumaticAxisGroup; //Select the pneumatic group 1 or 2, to connect to the correct pressure sensor
-    nAirPressureValueRaw: INT; //Raw analog value from pressure sensors
     nAllowTimePressureOutOfRange: INT; //User defined allowed time in seconds for the duration of air pressure value fluctuation
     fLowLimitPressureValue: REAL; //User defined value in bar for low limit air pressure value
     fHighLimitPressureValue: REAL; //User defined value in bar for low limit air pressure value

--- a/DUTs/Pneumatics/ST_PneumaticAxisConfig.TcDUT
+++ b/DUTs/Pneumatics/ST_PneumaticAxisConfig.TcDUT
@@ -8,7 +8,7 @@ STRUCT
     nTimeToExtend: INT; //User defined time for the cylider to extract in seconds
     nTimeToRetract: INT; //User defined time for the cylinder to retract in seconds
     eSelectPneumaticAxisGroup: E_PneumaticAxisGroup; //Select the pneumatic group 1 or 2, to connect to the correct pressure sensor
-    nAllowTimePressureOutOfRange: INT; //User defined allowed time in seconds for the duration of air pressure value fluctuation
+    tAllowTimePressureOutOfRange: TIME; //User defined allowed time in seconds for the duration of air pressure value fluctuation
     fLowLimitPressureValue: REAL; //User defined value in bar for low limit air pressure value
     fHighLimitPressureValue: REAL; //User defined value in bar for low limit air pressure value
 END_STRUCT

--- a/DUTs/Pneumatics/ST_PneumaticAxisInputs.TcDUT
+++ b/DUTs/Pneumatics/ST_PneumaticAxisInputs.TcDUT
@@ -5,7 +5,6 @@
 STRUCT
     bEndSwitchFwd AT %I*: BOOL; //End Switch Fwd input
     bEndSwitchBwd AT %I*: BOOL; //End Switch Bwd input
-    bPSSPermit AT %I*: BOOL; //Input signal from PSS for the movement
     fPressureValueScaled: REAL; //Scaled value from analog air pressure sensor for pneumatic valve in bar
     bOpenManual AT %I*: BOOL; //Push button input to extend cylinder
     bCloseManual AT %I*: BOOL; //Push button input to retract the cylinder

--- a/DUTs/Pneumatics/ST_PneumaticAxisOutputs.TcDUT
+++ b/DUTs/Pneumatics/ST_PneumaticAxisOutputs.TcDUT
@@ -5,7 +5,6 @@
 STRUCT
     bEndSwitchesPowerON AT %Q*: BOOL := TRUE; //Power output for pneumatic axis end switches
     bValveOn AT %Q*: BOOL; //Output of the solenoid valve (for single solenoid)
-    bAirPressurePowerON AT %Q*: BOOL := TRUE; //Power output for analog pressure sensor
 END_STRUCT
 END_TYPE
 ]]></Declaration>

--- a/GVLs/GVL.TcGVL
+++ b/GVLs/GVL.TcGVL
@@ -12,7 +12,7 @@
     astAxes: ARRAY [1..GVL_APP.nAXIS_NUM] OF ST_AxisStruct; //Array of ST_AxisStruct for holding axis parameters and controls
     astPneumaticAxes: ARRAY [1..GVL_APP.nPNEUMATIC_AXIS_NUM] OF ST_PneumaticAxisStruct; //Array of ST_PneumaticAxisStruct for holding pneumatic axis parameters and controls
     iAxis: UINT; //Index for for loops while going through axes
-    iPneumaticAxis: UINT := 1; //Index for for loops while going through pneumatic axes
+    iPneumaticAxis: UINT; //Index for for loops while going through pneumatic axes
     fbGetCurTaskIndex: GETCURTASKINDEX;
     bLocalMode: BOOL;
     nAirPressureSensorGroup1 AT %I*: INT; //Raw value from analog air pressure sensor for pneumatic axes group 1

--- a/POUs/Pneumatics/FB_PneumaticAxis.TcPOU
+++ b/POUs/Pneumatics/FB_PneumaticAxis.TcPOU
@@ -147,10 +147,10 @@ VAR
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[fbTimerAirPressureErrorLow(IN :=,PT:=INT_TO_TIME( _stPneumaticAxis.stPneumaticAxisConfig.nAllowTimePressureOutOfRange)*1000, Q=>,ET=>);
-fbTimerAirPressureErrorHigh(IN :=,PT:=INT_TO_TIME( _stPneumaticAxis.stPneumaticAxisConfig.nAllowTimePressureOutOfRange)*1000, Q=>,ET=>);
-fbTimerAirPressureNoErrorLow(IN :=,PT:=INT_TO_TIME( _stPneumaticAxis.stPneumaticAxisConfig.nAllowTimePressureOutOfRange)*1000, Q=>,ET=>);
-fbTimerAirPressureNoErrorHigh(IN :=,PT:=INT_TO_TIME( _stPneumaticAxis.stPneumaticAxisConfig.nAllowTimePressureOutOfRange)*1000, Q=>,ET=>);
+        <ST><![CDATA[fbTimerAirPressureErrorLow(IN :=,PT:= _stPneumaticAxis.stPneumaticAxisConfig.tAllowTimePressureOutOfRange, Q=>,ET=>);
+fbTimerAirPressureErrorHigh(IN :=,PT:= _stPneumaticAxis.stPneumaticAxisConfig.tAllowTimePressureOutOfRange, Q=>,ET=>);
+fbTimerAirPressureNoErrorLow(IN :=,PT:= _stPneumaticAxis.stPneumaticAxisConfig.tAllowTimePressureOutOfRange, Q=>,ET=>);
+fbTimerAirPressureNoErrorHigh(IN :=,PT:= _stPneumaticAxis.stPneumaticAxisConfig.tAllowTimePressureOutOfRange, Q=>,ET=>);
 
 //Check if the air pressure value is too low for longer than defined time
 IF _stPneumaticAxis.stPneumaticAxisInputs.fPressureValueScaled < _stPneumaticAxis.stPneumaticAxisConfig.fLowLimitPressureValue  THEN
@@ -566,14 +566,14 @@ mScaledPressureValue:= rGradient * nRawValue + rOffset;
         <ST><![CDATA[CASE _stPneumaticAxis.stPneumaticAxisConfig.eSelectPneumaticAxisGroup OF
 
         E_PneumaticAxisGroup.ePneumaticAxisGroup1:
-        _stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw := GVL.nAirPressureSensorGroup1;
+            _stPneumaticAxis.stPneumaticAxisInputs.fPressureValueScaled := mScaledPressureValue(nRawValue := GVL.nAirPressureSensorGroup1,
+                fRawHigh := 30518, fRawLow :=0, fScaledHigh := 10, fScaledLow := 0 );
 
         E_PneumaticAxisGroup.ePneumaticAxisGroup2:
-        _stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw := GVL.nAirPressureSensorGroup2;
+            _stPneumaticAxis.stPneumaticAxisInputs.fPressureValueScaled := mScaledPressureValue(nRawValue := GVL.nAirPressureSensorGroup2,
+                fRawHigh := 30518, fRawLow :=0, fScaledHigh := 10, fScaledLow := 0 );
 
     END_CASE
-
-_stPneumaticAxis.stPneumaticAxisInputs.fPressureValueScaled := mScaledPressureValue(nRawValue :=  _stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw, fRawHigh := 30518, fRawLow :=0, fScaledHigh := 10, fScaledLow := 0 );
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/Pneumatics/FB_PneumaticAxis.TcPOU
+++ b/POUs/Pneumatics/FB_PneumaticAxis.TcPOU
@@ -132,8 +132,8 @@ END_IF
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF _stPneumaticAxis.stPneumaticAxisOutputs.bValveOn
-AND NOT _stPneumaticAxis.stPneumaticAxisStatus.bExtended
-AND bStateChange THEN
+ AND NOT _stPneumaticAxis.stPneumaticAxisStatus.bExtended
+ AND bStateChange THEN
     _stPneumaticAxis.ePneumaticAxisErrors := E_PneumaticAxisErrors.eNoSignalFromEndSwitchFwd;
     _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eError;
 END_IF
@@ -234,14 +234,15 @@ END_IF
       <Implementation>
         <ST><![CDATA[IF _stPneumaticAxis.stPneumaticAxisConfig.bSafetyShutter THEN
     _stPneumaticAxis.stPneumaticAxisControl.bInterlock := FALSE;
-    ELSIF _stPneumaticAxis.stPneumaticAxisControl.bInterlock THEN
+ELSIF _stPneumaticAxis.stPneumaticAxisControl.bInterlock THEN
     _stPneumaticAxis.stPneumaticAxisStatus.sStatus := 'WARNING: INTERLOCK ON, CAN NOT MOVE';
-        IF _stPneumaticAxis.stPneumaticAxisStatus.bRetracted OR _stPneumaticAxis.stPneumaticAxisStatus.bRetracting THEN
+    IF _stPneumaticAxis.stPneumaticAxisStatus.bRetracted OR _stPneumaticAxis.stPneumaticAxisStatus.bRetracting THEN
         _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eCylinderRetractInterlocked;
-        END_IF
-        IF _stPneumaticAxis.stPneumaticAxisStatus.bExtended OR _stPneumaticAxis.stPneumaticAxisStatus.bExtending THEN
+    END_IF
+
+    IF _stPneumaticAxis.stPneumaticAxisStatus.bExtended OR _stPneumaticAxis.stPneumaticAxisStatus.bExtending THEN
         _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eCylinderExtendInterlocked;
-        END_IF
+    END_IF
 END_IF
 
 
@@ -338,12 +339,12 @@ _stPneumaticAxis.stPneumaticAxisStatus.bRetracting := FALSE;
 IF _stPneumaticAxis.stPneumaticAxisInputs.fPressureValueScaled <= _stPneumaticAxis.stPneumaticAxisConfig.fHighLimitPressureValue THEN
     fbTimerAirPressureNoErrorHigh.IN := TRUE;
     IF fbTimerAirPressureNoErrorHigh.Q THEN
-    _stPneumaticAxis.stPneumaticAxisStatus.bAirPressureHigh := FALSE;
-    _stPneumaticAxis.stPneumaticAxisStatus.bError := FALSE;
-    fbTimerAirPressureErrorHigh.IN := FALSE;
-    _stPneumaticAxis.stPneumaticAxisStatus.sStatus := 'NO_ERRORS_READY_TO_START';
-    _stPneumaticAxis.ePneumaticAxisErrors := E_PneumaticAxisErrors.eNoError;
-    _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eSingleSolenoidControl;
+        _stPneumaticAxis.stPneumaticAxisStatus.bAirPressureHigh := FALSE;
+        _stPneumaticAxis.stPneumaticAxisStatus.bError := FALSE;
+        fbTimerAirPressureErrorHigh.IN := FALSE;
+        _stPneumaticAxis.stPneumaticAxisStatus.sStatus := 'NO_ERRORS_READY_TO_START';
+        _stPneumaticAxis.ePneumaticAxisErrors := E_PneumaticAxisErrors.eNoError;
+        _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eSingleSolenoidControl;
     END_IF
 END_IF
 ]]></ST>
@@ -371,12 +372,12 @@ _stPneumaticAxis.stPneumaticAxisStatus.bRetracting := FALSE;
 IF _stPneumaticAxis.stPneumaticAxisInputs.fPressureValueScaled >= _stPneumaticAxis.stPneumaticAxisConfig.fLowLimitPressureValue THEN
     fbTimerAirPressureNoErrorLow.IN := TRUE;
     IF fbTimerAirPressureNoErrorLow.Q THEN
-    _stPneumaticAxis.stPneumaticAxisStatus.bAirPressureLow := FALSE;
-    _stPneumaticAxis.stPneumaticAxisStatus.bError := FALSE;
-    fbTimerAirPressureErrorLow.IN := FALSE;
-    _stPneumaticAxis.stPneumaticAxisStatus.sStatus := 'NO_ERRORS_READY_TO_START';
-    _stPneumaticAxis.ePneumaticAxisErrors := E_PneumaticAxisErrors.eNoError;
-    _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eSingleSolenoidControl;
+        _stPneumaticAxis.stPneumaticAxisStatus.bAirPressureLow := FALSE;
+        _stPneumaticAxis.stPneumaticAxisStatus.bError := FALSE;
+        fbTimerAirPressureErrorLow.IN := FALSE;
+        _stPneumaticAxis.stPneumaticAxisStatus.sStatus := 'NO_ERRORS_READY_TO_START';
+        _stPneumaticAxis.ePneumaticAxisErrors := E_PneumaticAxisErrors.eNoError;
+        _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eSingleSolenoidControl;
     END_IF
 END_IF
 ]]></ST>
@@ -390,26 +391,28 @@ END_IF
         <ST><![CDATA[_stPneumaticAxis.stPneumaticAxisControl.bInterlock := FALSE;
 _stPneumaticAxis.stPneumaticAxisOutputs.bValveOn := FALSE;
 _stPneumaticAxis.stPneumaticAxisStatus.sStatus := 'WARNING: NO PERMIT SIGNAL.';
-IF (_stPneumaticAxis.stPneumaticAxisControl.bExtend OR _stPneumaticAxis.stPneumaticAxisInputs.bOpenManual OR _stPneumaticAxis.stPneumaticAxisControl.bRetract OR _stPneumaticAxis.stPneumaticAxisInputs.bCloseManual) OR bNoPSSPermitError THEN
+IF (_stPneumaticAxis.stPneumaticAxisControl.bExtend
+ OR _stPneumaticAxis.stPneumaticAxisInputs.bOpenManual
+ OR _stPneumaticAxis.stPneumaticAxisControl.bRetract
+ OR _stPneumaticAxis.stPneumaticAxisInputs.bCloseManual) OR bNoPSSPermitError THEN
     _stPneumaticAxis.ePneumaticAxisErrors := E_PneumaticAxisErrors.eNoPSSPermit;
     _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eNoPSSPermitError;
 END_IF
 IF _stPneumaticAxis.stPneumaticAxisStatus.bPSSPermitOK THEN
-        _stPneumaticAxis.stPneumaticAxisOutputs.bValveOn := FALSE;
-        _stPneumaticAxis.stPneumaticAxisControl.bExtend := FALSE;
-        _stPneumaticAxis.stPneumaticAxisControl.bRetract := FALSE;
-        bStateChange := FALSE;
-        bStartExtendPLC := FALSE;
-        bStartExtendManual := FALSE;
-        bStartRetractManual := FALSE;
-        bStartRetractPLC := FALSE;
-        _stPneumaticAxis.stPneumaticAxisStatus.bExtending := FALSE;
-        _stPneumaticAxis.stPneumaticAxisStatus.bRetracting := FALSE;
-        _stPneumaticAxis.stPneumaticAxisStatus.bError := FALSE;
-        _stPneumaticAxis.stPneumaticAxisStatus.sStatus := 'NO_ERRORS_READY_TO_START';
-        _stPneumaticAxis.ePneumaticAxisErrors := E_PneumaticAxisErrors.eNoError;
-        _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eSingleSolenoidControl;
-
+    _stPneumaticAxis.stPneumaticAxisOutputs.bValveOn := FALSE;
+    _stPneumaticAxis.stPneumaticAxisControl.bExtend := FALSE;
+    _stPneumaticAxis.stPneumaticAxisControl.bRetract := FALSE;
+    bStateChange := FALSE;
+    bStartExtendPLC := FALSE;
+    bStartExtendManual := FALSE;
+    bStartRetractManual := FALSE;
+    bStartRetractPLC := FALSE;
+    _stPneumaticAxis.stPneumaticAxisStatus.bExtending := FALSE;
+    _stPneumaticAxis.stPneumaticAxisStatus.bRetracting := FALSE;
+    _stPneumaticAxis.stPneumaticAxisStatus.bError := FALSE;
+    _stPneumaticAxis.stPneumaticAxisStatus.sStatus := 'NO_ERRORS_READY_TO_START';
+    _stPneumaticAxis.ePneumaticAxisErrors := E_PneumaticAxisErrors.eNoError;
+    _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eSingleSolenoidControl;
 END_IF
 ]]></ST>
       </Implementation>
@@ -434,22 +437,21 @@ _stPneumaticAxis.stPneumaticAxisStatus.bRetracting := FALSE;
 _stPneumaticAxis.stPneumaticAxisStatus.sStatus := 'ERROR: NO PERMIT SIGNAL.';
 
 IF _stPneumaticAxis.stPneumaticAxisStatus.bPSSPermitOK THEN
-        bNoPSSPermitError := FALSE;
-        _stPneumaticAxis.stPneumaticAxisOutputs.bValveOn := FALSE;
-        _stPneumaticAxis.stPneumaticAxisControl.bExtend := FALSE;
-        _stPneumaticAxis.stPneumaticAxisControl.bRetract := FALSE;
-        bStateChange := FALSE;
-        bStartExtendPLC := FALSE;
-        bStartExtendManual := FALSE;
-        bStartRetractManual := FALSE;
-        bStartRetractPLC := FALSE;
-        _stPneumaticAxis.stPneumaticAxisStatus.bExtending := FALSE;
-        _stPneumaticAxis.stPneumaticAxisStatus.bRetracting := FALSE;
-        _stPneumaticAxis.stPneumaticAxisStatus.bError := FALSE;
-        _stPneumaticAxis.stPneumaticAxisStatus.sStatus := 'NO_ERRORS_READY_TO_START';
-        _stPneumaticAxis.ePneumaticAxisErrors := E_PneumaticAxisErrors.eNoError;
-        _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eSingleSolenoidControl;
-
+    bNoPSSPermitError := FALSE;
+    _stPneumaticAxis.stPneumaticAxisOutputs.bValveOn := FALSE;
+    _stPneumaticAxis.stPneumaticAxisControl.bExtend := FALSE;
+    _stPneumaticAxis.stPneumaticAxisControl.bRetract := FALSE;
+    bStateChange := FALSE;
+    bStartExtendPLC := FALSE;
+    bStartExtendManual := FALSE;
+    bStartRetractManual := FALSE;
+    bStartRetractPLC := FALSE;
+    _stPneumaticAxis.stPneumaticAxisStatus.bExtending := FALSE;
+    _stPneumaticAxis.stPneumaticAxisStatus.bRetracting := FALSE;
+    _stPneumaticAxis.stPneumaticAxisStatus.bError := FALSE;
+    _stPneumaticAxis.stPneumaticAxisStatus.sStatus := 'NO_ERRORS_READY_TO_START';
+    _stPneumaticAxis.ePneumaticAxisErrors := E_PneumaticAxisErrors.eNoError;
+    _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eSingleSolenoidControl;
 END_IF
 ]]></ST>
       </Implementation>
@@ -533,7 +535,6 @@ mCheckForAirPressureError();
 
 //Reset Error
 mReset();
-
 ]]></ST>
       </Implementation>
     </Method>
@@ -574,8 +575,7 @@ mScaledPressureValue:= rGradient * nRawValue + rOffset;
         E_PneumaticAxisGroup.ePneumaticAxisGroup2:
             _stPneumaticAxis.stPneumaticAxisInputs.fPressureValueScaled := mScaledPressureValue(nRawValue := GVL.nAirPressureSensorGroup2,
                 fRawHigh := 30518, fRawLow :=0, fScaledHigh := 10, fScaledLow := 0 );
-
-    END_CASE
+END_CASE
 ]]></ST>
       </Implementation>
     </Method>
@@ -654,7 +654,8 @@ IF (bStartExtendPLC OR bStartExtendManual) THEN
     END_IF
     //If the command to retract is given after the valve was activated
     IF NOT _stPneumaticAxis.stPneumaticAxisStatus.bExtended
-          AND NOT _stPneumaticAxis.stPneumaticAxisStatus.bRetracted OR _stPneumaticAxis.stPneumaticAxisStatus.bRetracted THEN
+       AND NOT _stPneumaticAxis.stPneumaticAxisStatus.bRetracted
+       OR _stPneumaticAxis.stPneumaticAxisStatus.bRetracted THEN
         IF (bStartRetractPLC OR bStartRetractManual) THEN
             _stPneumaticAxis.stPneumaticAxisOutputs.bValveOn := FALSE;
             _stPneumaticAxis.stPneumaticAxisStatus.bRetracting := TRUE;

--- a/POUs/Pneumatics/FB_PneumaticAxis.TcPOU
+++ b/POUs/Pneumatics/FB_PneumaticAxis.TcPOU
@@ -566,14 +566,11 @@ mScaledPressureValue:= rGradient * nRawValue + rOffset;
         <ST><![CDATA[CASE _stPneumaticAxis.stPneumaticAxisConfig.eSelectPneumaticAxisGroup OF
 
         E_PneumaticAxisGroup.ePneumaticAxisGroup1:
-        _stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw := nAirPressureSensorGroup1;
-        _stPneumaticAxis.stPneumaticAxisConfig.fLowLimitPressureValue := GVL_APP.fLOW_LIMIT_AIR_PRESSURE1;
-        _stPneumaticAxis.stPneumaticAxisConfig.fHighLimitPressureValue := GVL_APP.fHIGH_LIMIT_AIR_PRESSURE1;
+        _stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw := GVL.nAirPressureSensorGroup1;
 
         E_PneumaticAxisGroup.ePneumaticAxisGroup2:
-        _stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw := nAirPressureSensorGroup2;
-        _stPneumaticAxis.stPneumaticAxisConfig.fLowLimitPressureValue := GVL_APP.fLOW_LIMIT_AIR_PRESSURE2;
-        _stPneumaticAxis.stPneumaticAxisConfig.fHighLimitPressureValue := GVL_APP.fHIGH_LIMIT_AIR_PRESSURE2;
+        _stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw := GVL.nAirPressureSensorGroup2;
+
     END_CASE
 
 _stPneumaticAxis.stPneumaticAxisInputs.fPressureValueScaled := mScaledPressureValue(nRawValue :=  _stPneumaticAxis.stPneumaticAxisConfig.nAirPressureValueRaw, fRawHigh := 30518, fRawLow :=0, fScaledHigh := 10, fScaledLow := 0 );

--- a/POUs/Pneumatics/FB_PneumaticAxis.TcPOU
+++ b/POUs/Pneumatics/FB_PneumaticAxis.TcPOU
@@ -258,14 +258,16 @@ END_IF
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[IF NOT _stPneumaticAxis.stPneumaticAxisConfig.bSafetyShutter THEN
-    _stPneumaticAxis.stPneumaticAxisInputs.bPSSPermit := FALSE;
-ELSIF NOT _stPneumaticAxis.stPneumaticAxisInputs.bPSSPermit THEN
+    _stPneumaticAxis.stPneumaticAxisStatus.bPSSPermitOK := FALSE;
+    _stPneumaticAxis.stPneumaticAxisStatus.sStatus := 'NO_ERRORS_READY_TO_START';
+    _stPneumaticAxis.ePneumaticAxisErrors := E_PneumaticAxisErrors.eNoError;
+    _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eSingleSolenoidControl;
+ELSIF NOT _stPneumaticAxis.stPneumaticAxisStatus.bPSSPermitOK THEN
     _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eNoPSSPermit;
-    ELSIF _stPneumaticAxis.stPneumaticAxisInputs.bPSSPermit THEN
-        _stPneumaticAxis.stPneumaticAxisStatus.sStatus := 'NO_ERRORS_READY_TO_START';
-        _stPneumaticAxis.ePneumaticAxisErrors := E_PneumaticAxisErrors.eNoError;
-        _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eSingleSolenoidControl;
-
+ELSIF _stPneumaticAxis.stPneumaticAxisStatus.bPSSPermitOK THEN
+    _stPneumaticAxis.stPneumaticAxisStatus.sStatus := 'NO_ERRORS_READY_TO_START';
+    _stPneumaticAxis.ePneumaticAxisErrors := E_PneumaticAxisErrors.eNoError;
+    _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eSingleSolenoidControl;
 END_IF
 
 ]]></ST>
@@ -392,7 +394,7 @@ IF (_stPneumaticAxis.stPneumaticAxisControl.bExtend OR _stPneumaticAxis.stPneuma
     _stPneumaticAxis.ePneumaticAxisErrors := E_PneumaticAxisErrors.eNoPSSPermit;
     _stPneumaticAxis.ePneumaticAxisMode := E_PneumaticMode.eNoPSSPermitError;
 END_IF
-IF _stPneumaticAxis.stPneumaticAxisInputs.bPSSPermit THEN
+IF _stPneumaticAxis.stPneumaticAxisStatus.bPSSPermitOK THEN
         _stPneumaticAxis.stPneumaticAxisOutputs.bValveOn := FALSE;
         _stPneumaticAxis.stPneumaticAxisControl.bExtend := FALSE;
         _stPneumaticAxis.stPneumaticAxisControl.bRetract := FALSE;
@@ -431,7 +433,7 @@ _stPneumaticAxis.stPneumaticAxisStatus.bExtending := FALSE;
 _stPneumaticAxis.stPneumaticAxisStatus.bRetracting := FALSE;
 _stPneumaticAxis.stPneumaticAxisStatus.sStatus := 'ERROR: NO PERMIT SIGNAL.';
 
-IF _stPneumaticAxis.stPneumaticAxisInputs.bPSSPermit THEN
+IF _stPneumaticAxis.stPneumaticAxisStatus.bPSSPermitOK THEN
         bNoPSSPermitError := FALSE;
         _stPneumaticAxis.stPneumaticAxisOutputs.bValveOn := FALSE;
         _stPneumaticAxis.stPneumaticAxisControl.bExtend := FALSE;
@@ -596,7 +598,6 @@ fbTimerRetract.PT := INT_TO_TIME( _stPneumaticAxis.stPneumaticAxisConfig.nTimeTo
 //Check if cylinder is moving: extending or retracting
 _stPneumaticAxis.stPneumaticAxisStatus.bRetracted := _stPneumaticAxis.stPneumaticAxisInputs.bEndSwitchBwd;
 _stPneumaticAxis.stPneumaticAxisStatus.bExtended := _stPneumaticAxis.stPneumaticAxisInputs.bEndSwitchFwd;
-_stPneumaticAxis.stPneumaticAxisStatus.bPSSPermitOK := _stPneumaticAxis.stPneumaticAxisInputs.bPSSPermit;
 _stPneumaticAxis.stPneumaticAxisStatus.bInterlocked := _stPneumaticAxis.stPneumaticAxisControl.bInterlock;
 ]]></ST>
       </Implementation>

--- a/VISUs/MainVisu.TcVIS
+++ b/VISUs/MainVisu.TcVIS
@@ -20676,7 +20676,7 @@ GVL.astAxes[Main.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                     </o>
                     <o>
                       <v n="Id">357335551L</v>
-                      <v n="Value">75</v>
+                      <v n="Value">76</v>
                     </o>
                     <o>
                       <v n="Id">2422045748L</v>
@@ -20715,7 +20715,7 @@ GVL.astAxes[Main.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                     </o>
                     <o>
                       <v n="Id">1473355128L</v>
-                      <v n="Value">90</v>
+                      <v n="Value">91</v>
                     </o>
                     <o>
                       <v n="Id">493260384L</v>
@@ -20732,6 +20732,10 @@ GVL.astAxes[Main.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                     <o>
                       <v n="Id">2597686782L</v>
                       <v n="Value">false</v>
+                    </o>
+                    <o>
+                      <v n="Id">2477733581L</v>
+                      <v n="Value">"GVL.bLocalMode"</v>
                     </o>
                   </l>
                 </o>
@@ -21375,6 +21379,10 @@ GVL.astAxes[Main.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                     <o>
                       <v n="Id">2597686782L</v>
                       <v n="Value">false</v>
+                    </o>
+                    <o>
+                      <v n="Id">2477733581L</v>
+                      <v n="Value">"GVL.astAxes[MAIN.hmiAxisSelection].stControl.bHWMaskActive"</v>
                     </o>
                   </l>
                 </o>

--- a/VISUs/PneumaticsVisu.TcVIS
+++ b/VISUs/PneumaticsVisu.TcVIS
@@ -7439,7 +7439,7 @@
                     </o>
                     <o>
                       <v n="Id">743958181L</v>
-                      <v n="Value">"GVL.astPneumaticAxes[MAIN.hmiPneumaticAxisSelection].stPneumaticAxisInputs.bPSSPermit"</v>
+                      <v n="Value">"GVL.astPneumaticAxes[MAIN.hmiPneumaticAxisSelection].stPneumaticAxisStatus.bPSSPermitOK"</v>
                     </o>
                   </l>
                 </o>
@@ -8131,7 +8131,7 @@
                     </o>
                     <o>
                       <v n="Id">357335551L</v>
-                      <v n="Value">400</v>
+                      <v n="Value">401</v>
                     </o>
                     <o>
                       <v n="Id">2422045748L</v>
@@ -8839,8 +8839,8 @@
                       <v n="Id">2812299069L</v>
                       <l n="Value" t="ArrayList" cet="NamedStyleColor">
                         <o>
-                          <v n="Color">-1</v>
-                          <v n="CanonicalName">"White"</v>
+                          <v n="Color">-1381912</v>
+                          <v n="CanonicalName">"Element-Background-Color"</v>
                         </o>
                       </l>
                     </o>
@@ -8947,7 +8947,7 @@
                     </o>
                     <o>
                       <v n="Id">390574330L</v>
-                      <v n="Value">"%d"</v>
+                      <v n="Value">"%s"</v>
                     </o>
                     <o>
                       <v n="Id">2597686782L</v>
@@ -8955,45 +8955,26 @@
                     </o>
                     <o>
                       <v n="Id">2477733581L</v>
-                      <v n="Value">"GVL.astPneumaticAxes[MAIN.hmiPneumaticAxisSelection].stPneumaticAxisConfig.nAllowTimePressureOutOfRange"</v>
+                      <v n="Value">"astPneumaticAxes[MAIN.hmiPneumaticAxisSelection].stPneumaticAxisConfig.tAllowTimePressureOutOfRange"</v>
                     </o>
                     <o>
                       <v n="Id">823443203L</v>
-                      <v n="Value">"982"</v>
+                      <v n="Value">"821"</v>
                     </o>
                   </l>
                 </o>
                 <v n="VisualElementName">"Textfield"</v>
                 <v n="VisualElementTypeName">"VisuFbElemTextfield"</v>
                 <v n="VisualElementIsRectangle">true</v>
-                <v n="VisualElementIdentifier">"GenElemInst_222"</v>
+                <v n="VisualElementIdentifier">"GenElemInst_224"</v>
                 <n n="VisualElementOfflinePaintCommands" />
                 <n n="VisualElementFrameInformation" />
-                <d n="VisualElementInputActions" t="Hashtable" ckt="String" cvt="InputBoxInputAction[]">
-                  <v>OnMouseClick</v>
-                  <a cet="InputBoxInputAction">
-                    <o>
-                      <v n="InputBoxVariable">""</v>
-                      <v n="InputType">"Default"</v>
-                      <v n="InputBoxMin">""</v>
-                      <v n="InputBoxMax">""</v>
-                      <v n="InputBoxDialogTitle">""</v>
-                      <v n="Password">false</v>
-                      <v n="UseTextOutputVariable">true</v>
-                      <v n="TextOutputVariableInitialized">true</v>
-                      <v n="OtherVarConversion">""</v>
-                      <v n="Format">""</v>
-                      <v n="DialogPosition" t="DialogPositionSetting">UseGlobalSetting</v>
-                      <v n="DialogXPos">""</v>
-                      <v n="DialogYPos">""</v>
-                    </o>
-                  </a>
-                </d>
-                <v n="VisualElementIdentification">{61f09790-3cc8-4cd7-995c-820dfbcb81ca}</v>
+                <d n="VisualElementInputActions" t="Hashtable" />
+                <v n="VisualElementIdentification">{49f30cf0-e324-49e3-9050-50d0a0625eaf}</v>
                 <v n="VisualElementOwningObjectGuid">{b76d4b7c-f950-06ce-2833-75b1a7141b87}</v>
                 <a n="LMGuids" et="Guid" />
                 <d n="SubElements" t="Hashtable" />
-                <v n="VisualElementId">217</v>
+                <v n="VisualElementId">220</v>
                 <l n="UserManagementAccessRights" t="ArrayList" />
               </o>
             </l>
@@ -9145,7 +9126,7 @@
             </o>
             <v n="DialogDut">{d940e417-8e07-4eb6-b115-3f87dce1720f}</v>
           </o>
-          <v n="LastUsedIdForIdentifier">222</v>
+          <v n="LastUsedIdForIdentifier">224</v>
           <o n="TextDocument" t="TextDocument">
             <a n="TextLines" cet="TextLine">
               <o>


### PR DESCRIPTION
Checkout the branch, build solution and test that all pneumatic functionalities have not change. To be able to test it correctly you will need some programs in tc_generic_Strucutre branch federicor/progs-for-pneumatics.

- Remove the variable bAirpressurePower from the st_outputs of the pneumatics axis. It will be included in the pneumatic_box PROG in the application specific section.

- Move bPSSPermit from the st_input to the st_status and change it to a normal variable instead of a %I*.

- In GVL delete the initial value of iPneumaticAxis. We are setting it to 1 in the MAIN/AXES().

- The variable .stPneumaticAxisConfig.nAllowTimePressureOutOfRange will be linked to moved to GVL_APP as tTIME_PRESSURE_OUT_OF_RANGE: TIME := T#10S in Pneumatics_template.

- Remove any GVL_APP variables inside the FB_AxisPneuamtics so it can build without errors without the need of external variables

