### PR TITLE
Mbp 314 histeresis and error for motor pt100

### DIFF
--- a/DUTs/Axis_Structures/ST_AxisError.TcDUT
+++ b/DUTs/Axis_Structures/ST_AxisError.TcDUT
@@ -20,6 +20,8 @@ STRUCT
     nBacklashErrorID: UDINT; //Error ID for MC_BacklashCompensation function block
 //Error from the NC
     nNCErrorID : UDINT; //Error ID from the NC Axis_Ref Axis Status
+//PT100 temperature sensor error
+    bTempSensorError: BOOL; //Error when PTQOO is wrongly connected or disconnected
 END_STRUCT
 END_TYPE
 ]]></Declaration>

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -124,8 +124,7 @@ END_VAR
       <Declaration><![CDATA[METHOD EndOfCycle : BOOL
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-_stAxis.stControl.bExecute := FALSE;
+        <ST><![CDATA[_stAxis.stControl.bExecute := FALSE;
 ]]></ST>
       </Implementation>
     </Method>
@@ -137,8 +136,7 @@ VAR_INPUT
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-//Copy address locations for statuses to an array to allow for easier checking of statuses
+        <ST><![CDATA[//Copy address locations for statuses to an array to allow for easier checking of statuses
 astMcStatus[1] := ADR(stMcStatusPower);
 astMcStatus[2] := ADR(stMcStatusStop);
 astMcStatus[3] := ADR(stMcStatusHalt);
@@ -201,8 +199,7 @@ _stAxis.stStatus.bBacklashCompensating := fbBacklashCompensation.Limiting;
       <Declaration><![CDATA[METHOD mControl_GearInMultiMaster : ST_McStatus
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-fbGearInMultiMaster.Options.AdvancedSlaveDynamics := TRUE;
+        <ST><![CDATA[fbGearInMultiMaster.Options.AdvancedSlaveDynamics := TRUE;
 fbGearInMultiMaster.Options.SyncMode := E_GearInMultiMasterSyncMode.POSSYNC2;
 IF _stAxis.stControl.eCommand = E_MotionFunctions.eGearInMultiMaster THEN
     fbGearInMultiMaster.Enable := _stAxis.stControl.bExecute;
@@ -259,8 +256,7 @@ END_IF
       <Declaration><![CDATA[METHOD mControl_GearOut : ST_McStatus
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-IF _stAxis.stControl.eCommand = E_MotionFunctions.eGearOut THEN
+        <ST><![CDATA[IF _stAxis.stControl.eCommand = E_MotionFunctions.eGearOut THEN
     fbGearOut.Execute := _stAxis.stControl.bExecute;
 END_IF
 
@@ -327,8 +323,7 @@ END_IF
       <Declaration><![CDATA[METHOD mControl_LimitHitTimer : BOOL
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-//Timer for keeping power on after limit switch hit, needed for homing routines - if power is lost routines are aborted
+        <ST><![CDATA[//Timer for keeping power on after limit switch hit, needed for homing routines - if power is lost routines are aborted
 fbRemovePowerTimer(IN := _stAxis.stInputs.bLimitFwd AND _stAxis.stInputs.bLimitBwd, PT := T#100MS);
 
 IF stMcStatusHome.Busy AND (fbRemovePowerTimer.Q OR _stAxis.Axis.NcToPlc.AxisState = 5) THEN //5=PHASE_ACCNEG
@@ -544,8 +539,7 @@ END_IF
       <Declaration><![CDATA[METHOD mMove_Halt : ST_McStatus
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-fbHalt.Deceleration := _stAxis.stControl.fDeceleration;
+        <ST><![CDATA[fbHalt.Deceleration := _stAxis.stControl.fDeceleration;
 fbHalt.Execute := _stAxis.stControl.bHalt;
 
 fbHalt(Axis := _stAxis.Axis);
@@ -683,8 +677,7 @@ END_IF
       <Declaration><![CDATA[METHOD mMove_MoveRelative : ST_McStatus
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-IF _stAxis.stControl.eCommand = E_MotionFunctions.eMoveRelative THEN
+        <ST><![CDATA[IF _stAxis.stControl.eCommand = E_MotionFunctions.eMoveRelative THEN
     fbMoveRelative.Execute := _stAxis.stControl.bExecute;
 END_IF
 
@@ -713,8 +706,7 @@ END_IF
       <Declaration><![CDATA[METHOD mMove_MoveVelocity : ST_McStatus
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-IF _stAxis.stControl.eCommand = E_MotionFunctions.eMoveVelocity THEN
+        <ST><![CDATA[IF _stAxis.stControl.eCommand = E_MotionFunctions.eMoveVelocity THEN
     fbMoveVelocity.Execute := _stAxis.stControl.bExecute;
 END_IF
 
@@ -743,8 +735,7 @@ END_IF
       <Declaration><![CDATA[METHOD mMove_Stop : ST_McStatus
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-fbStop.Deceleration := _stAxis.stControl.fDeceleration;
+        <ST><![CDATA[fbStop.Deceleration := _stAxis.stControl.fDeceleration;
 fbStop.Execute := _stAxis.stControl.bStop;
 
 fbStop(Axis := _stAxis.Axis);
@@ -772,8 +763,7 @@ END_IF
       <Declaration><![CDATA[METHOD mParameters_Init : BOOL
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-IF _stAxis.stConfig.bReadMcParametersValid AND NOT _stAxis.stStatus.bAxisInitialized THEN
+        <ST><![CDATA[IF _stAxis.stConfig.bReadMcParametersValid AND NOT _stAxis.stStatus.bAxisInitialized THEN
     _stAxis.stControl.fAcceleration := _stAxis.stConfig.fDefaultAcc;
     _stAxis.stControl.fDeceleration := _stAxis.stConfig.fDefaultDec;
     _stAxis.stControl.fVelocity := _stAxis.stConfig.fVelocityDefaultFast;
@@ -790,8 +780,7 @@ END_IF
       <Declaration><![CDATA[METHOD mParameters_ReadNc : BOOL
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-(*This act reads the MC parameters using an MC_ReadParameter FB FOR each variable
+        <ST><![CDATA[(*This act reads the MC parameters using an MC_ReadParameter FB FOR each variable
 Intended TO be executed once every PLC cycle
 Another FB is used TO trasnfer default axis parameters TO the stAxisStruct so
 bReadValid is used TO halt that trasnfer UNTIL the parameters have been
@@ -952,8 +941,7 @@ _stAxis.stConfig.bReadMcParametersError := fbReadAxisVeloManSlow.Error OR
       <Declaration><![CDATA[METHOD mParameters_ReadParameter : ST_McStatus
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-IF _stAxis.stControl.eCommand = E_MotionFunctions.eReadParameter THEN
+        <ST><![CDATA[IF _stAxis.stControl.eCommand = E_MotionFunctions.eReadParameter THEN
     fbReadParameter.Enable := _stAxis.stControl.bExecute;
 END_IF
 
@@ -1114,8 +1102,7 @@ END_IF
       <Declaration><![CDATA[METHOD mParameters_WriteParameter : ST_McStatus
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-IF _stAxis.stControl.eCommand = E_MotionFunctions.eWriteParameter THEN
+        <ST><![CDATA[IF _stAxis.stControl.eCommand = E_MotionFunctions.eWriteParameter THEN
     fbWriteParameter.Execute := _stAxis.stControl.bExecute;
 END_IF
 
@@ -1140,8 +1127,7 @@ END_IF
       <Declaration><![CDATA[METHOD mStatus_AxisStatus : BOOL
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-_stAxis.Axis.ReadStatus();
+        <ST><![CDATA[_stAxis.Axis.ReadStatus();
 IF _stAxis.Axis.Status.OpMode.Modulo THEN
     _stAxis.stStatus.fActPosition := _stAxis.Axis.NcToPlc.ModuloActPos;
 ELSE
@@ -1168,8 +1154,7 @@ VAR
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-FOR i := 5 TO nMCSTATUS_ARRAY_SIZE DO
+        <ST><![CDATA[FOR i := 5 TO nMCSTATUS_ARRAY_SIZE DO
     tmpBusy := astMcStatus[i]^.Busy OR tmpBusy;
 END_FOR
 mStatus_Busy := tmpBusy;
@@ -1184,8 +1169,7 @@ VAR
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-FOR i := 5 TO nMCSTATUS_ARRAY_SIZE DO
+        <ST><![CDATA[FOR i := 5 TO nMCSTATUS_ARRAY_SIZE DO
     tmpCmdAborted := astMcStatus[i]^.CommandAborted OR tmpCmdAborted;
 END_FOR
 
@@ -1204,8 +1188,7 @@ VAR
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-FOR i := 5 TO nMCSTATUS_ARRAY_SIZE DO
+        <ST><![CDATA[FOR i := 5 TO nMCSTATUS_ARRAY_SIZE DO
     tmpDone := astMcStatus[i]^.Done OR tmpDone;
 END_FOR
 //fbDoneRTrig(CLK:= mStatus_Done());
@@ -1275,8 +1258,7 @@ END_IF
       <Declaration><![CDATA[METHOD mStatus_MultiGearing : BOOL
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-IF _stAxis.Axis.Status.Coupled AND _stAxis.Axis.PlcToNc.GearRatio1 <> 0 AND _stAxis.stConfig.astMultiMasterAxisLatched[1].nIndex <> 0 THEN
+        <ST><![CDATA[IF _stAxis.Axis.Status.Coupled AND _stAxis.Axis.PlcToNc.GearRatio1 <> 0 AND _stAxis.stConfig.astMultiMasterAxisLatched[1].nIndex <> 0 THEN
     GVL.astAxes[_stAxis.stConfig.astMultiMasterAxisLatched[1].nIndex].stConfig.afMultiSlaveAxisRatio[GVL.iAxis] := _stAxis.Axis.PlcToNc.GearRatio1;
     _stAxis.stStatus.bCoupledGear1 := TRUE;
 ELSE
@@ -1313,8 +1295,7 @@ VAR
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-fbExecuteRTrig(CLK := _stAxis.stControl.bExecute);
+        <ST><![CDATA[fbExecuteRTrig(CLK := _stAxis.stControl.bExecute);
 IF fbExecuteRTrig.Q THEN
     _stAxis.stStatus.bDone := FALSE;
     _stAxis.stStatus.bCommandAborted := FALSE;
@@ -1343,8 +1324,7 @@ END_IF
       <Declaration><![CDATA[METHOD Run : BOOL
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[
-mStatus_AxisStatus();
+        <ST><![CDATA[mStatus_AxisStatus();
 mParameters_ReadNc();
 mParameters_Init();
 stMcStatusReadParameter := mParameters_ReadParameter();

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -467,6 +467,7 @@ IF bEnableTemperatureDisable THEN
     IF fTemperatureValue >= fMAX_TEMP_LIMIT OR fTemperatureValue <= fMIN_TEMP_LIMIT THEN
         _stAxis.stStatus.fActTemperature := fTemperatureValue;
         _stAxis.stStatus.bHighTempAxisDisabled := TRUE;
+        _stAxis.stError.bTempSensorError := TRUE;
         bError := TRUE;
 
         IF fbErrorTrig.Q THEN
@@ -486,6 +487,8 @@ IF bEnableTemperatureDisable THEN
 
         mControl_TemperatureDisable := TRUE;
         RETURN;
+    ELSE
+        _stAxis.stError.bTempSensorError := FALSE;
     END_IF
 
     //Check scaled tempearture value agianst max. allowed temperature

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -452,6 +452,7 @@ VAR_INST
     fMAX_TEMP_LIMIT: LREAL := 850.0;
     fMIN_TEMP_LIMIT: LREAL := -200.0;
     bError: BOOL := FALSE;
+    bAxisWasDisabled: BOOL := FALSE;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -480,7 +481,7 @@ IF bEnableTemperatureDisable THEN
             END_IF
         END_IF
 
-        //Reset bError to display Error message every 10 seconds if error is still there
+        //Reset bError to display Error message every 30 seconds if error is still there
         IF fbErrorTON.Q THEN
             bError := FALSE;
         END_IF
@@ -492,17 +493,33 @@ IF bEnableTemperatureDisable THEN
     END_IF
 
     //Check scaled tempearture value agianst max. allowed temperature
-    IF fTemperatureValue < _stAXis.stConfig.fMaxTemperature THEN
+    IF fTemperatureValue < _stAXis.stConfig.fMaxTemperature AND NOT bAxisWasDisabled THEN
         bError := FALSE;
         sErrorMessage := '';
         _stAxis.stStatus.fActTemperature := fTemperatureValue;
         _stAxis.stStatus.bHighTempAxisDisabled := FALSE;
         mControl_TemperatureDisable := FALSE;
         RETURN;
+    ELSIF fTemperatureValue < _stAXis.stConfig.fMaxTemperature AND bAxisWasDisabled THEN
+        IF fTemperatureValue <= (_stAXis.stConfig.fMaxTemperature - 5.0) THEN
+            bError := FALSE;
+            sErrorMessage := '';
+            _stAxis.stStatus.fActTemperature := fTemperatureValue;
+            _stAxis.stStatus.bHighTempAxisDisabled := FALSE;
+            mControl_TemperatureDisable := FALSE;
+            bAxisWasDisabled := FALSE;
+            RETURN;
+        ELSE
+            bError := TRUE;
+            _stAxis.stStatus.fActTemperature := fTemperatureValue;
+            _stAxis.stStatus.bHighTempAxisDisabled := TRUE;
+            mControl_TemperatureDisable := TRUE;
+        END_IF
     ELSIF fTemperatureValue >= _stAXis.stConfig.fMaxTemperature THEN
         bError := TRUE;
         _stAxis.stStatus.fActTemperature := fTemperatureValue;
         _stAxis.stStatus.bHighTempAxisDisabled := TRUE;
+        bAxisWasDisabled := TRUE;
         IF fbErrorTrig.Q THEN
             sErrorMessage := CONCAT('ERROR: Axis temperature too hot. Cannot enable Axis ',UINT_TO_STRING(nAxisId));
             ADSLOGSTR( msgCtrlMask := ADSLOG_MSGTYPE_ERROR, msgFmtStr := '%s', strArg := sErrorMessage);


### PR DESCRIPTION
Add Error bit in ST_AxisError for a wrong connected or disconnected PT100.
Add hysteresis for the temperature measurement and motor disable.
If you reach equal or more than the specified Max temp, the motor will disabled. You will not be able to enable the motor until the temperature reaches 5 degrees less than Max temperature.

To test:
- If no PT100, activate HWMaskActive (Control), activate bEnableTemperatureDisable (Config), set a value for fMaxTemperature (Config).
- write a value less than fMaxTemperature in fMaskedTemperature (Control). Enable the motor. Check that the value matches with fActTemperature (Status)
- Write fMaskedTemperature as a value equal or greater than fMaxTemperature. Check that motor disables, Error message in TwinCAT and correct fActTemperature display. Try to enable axis, it should not be possible.
- Write fMaskedTemperature as a value 3 degrees less than fMaxTemperature. fActTemperature matches the values and try to enable axis, it should not be possible.
- Write fMaskedTemperature as a value 5 degrees less than fMaxTemperature. fActTemperature matches the values and try to enable axis, now it should be possible.
- Repeat everything again.