### PR TITLE
MBP-321: Fix homing bug when on limit switch

### DIFF
--- a/DUTs/E_CoEParamState.TcDUT
+++ b/DUTs/E_CoEParamState.TcDUT
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.11">
+<TcPlcObject Version="1.1.0.1">
   <DUT Name="E_CoEParamState" Id="{7b256909-45ff-4fb5-8610-f99052702492}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 {attribute 'strict'}

--- a/DUTs/E_CoEParameters.TcDUT
+++ b/DUTs/E_CoEParameters.TcDUT
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.11">
+<TcPlcObject Version="1.1.0.1">
   <DUT Name="E_CoEParameters" Id="{f0ad2286-4167-4944-8c96-01eefcb70ded}">
     <Declaration><![CDATA[{attribute 'qualified_only'}
 {attribute 'strict'}

--- a/POUs/Motion/Homing/FB_Homing.TcPOU
+++ b/POUs/Motion/Homing/FB_Homing.TcPOU
@@ -83,6 +83,7 @@ VAR
     eHomingState: (eWaitForRequest := 0, eCoarseDetection := 1, eMoveReverse := 2, eFineDetection := 3, eSetPos := 4, eFinishHoming := 5, eAbortHoming := 20);
     bHomingToHomeSensor: BOOL;
     bHomingToLimitSwitch: BOOL;
+    bHomingToEncoderPulse: BOOL;
 
     bTwoSpeedHoming:BOOL;
     bReversedDirection: BOOL;
@@ -210,6 +211,7 @@ CASE eHomingState OF
             bTwoSpeedHoming := FALSE;
             bHomingToHomeSensor := FALSE;
             bHomingToLimitSwitch := FALSE;
+            bHomingToEncoderPulse := FALSE;
             bReversedDirection := FALSE;
             bRisingEdgeDetectionOn := FALSE;
             bFallingEdgeDetectionOn := FALSE;
@@ -233,10 +235,14 @@ CASE eHomingState OF
                 END_IF
             ELSIF bTwoSpeedHoming THEN
                 IF NOT bBusy AND bHWSignalForHoming THEN
-                    IF (bHomingToHomeSensor OR bHomingToLimitSwitch) AND bFallingEdgeDetectionOn THEN
+                    IF (bHomingToHomeSensor OR bHomingToLimitSwitch)
+                        AND bFallingEdgeDetectionOn THEN
                         eHomingState := eFineDetection;
-                    ELSIF (bHomingToHomeSensor OR bHomingToLimitSwitch) AND bRisingEdgeDetectionOn THEN
+                    ELSIF (bHomingToHomeSensor OR bHomingToLimitSwitch)
+                        AND bRisingEdgeDetectionOn THEN
                         eHomingState := eMoveReverse;
+                    ELSIF bHomingToEncoderPulse THEN
+                        eHomingState := eFineDetection;
                     END_IF
                 ELSIF NOT bBusy AND NOT bHWSignalForHoming THEN
                     eHomingState := eCoarseDetection;
@@ -452,6 +458,8 @@ fbStepBlockLag(
         bHWSignalForHoming := NOT(bLimitBwd);
         bTwoSpeedHoming := TRUE;
 END_CASE
+
+bHomingToEncoderPulse := TRUE;
 
 IF bViaLimitCoarseDetect AND bTwoSpeedHoming THEN
    fbStepLimitSwitch.Options.DisableDriveAccess := stOptions.DisableDriveAccess;

--- a/POUs/Motion/Homing/FB_Homing.TcPOU
+++ b/POUs/Motion/Homing/FB_Homing.TcPOU
@@ -22,6 +22,7 @@ VAR_OUTPUT
     bError: BOOL;
     nErrorId: UDINT;
 END_VAR
+
 VAR
     bHWSignalForHoming: BOOL;
 
@@ -231,9 +232,9 @@ CASE eHomingState OF
                 END_IF
             ELSIF bTwoSpeedHoming THEN
                 IF NOT bBusy AND bHWSignalForHoming THEN
-                    IF bHomingToHomeSensor AND bFallingEdgeDetectionOn THEN
+                    IF (bHomingToHomeSensor OR bHomingToLimitSwitch) AND bFallingEdgeDetectionOn THEN
                         eHomingState := eFineDetection;
-                    ELSIF bHomingToHomeSensor AND bRisingEdgeDetectionOn THEN
+                    ELSIF (bHomingToHomeSensor OR bHomingToLimitSwitch) AND bRisingEdgeDetectionOn THEN
                         eHomingState := eMoveReverse;
                     END_IF
                 ELSIF NOT bBusy AND NOT bHWSignalForHoming THEN

--- a/POUs/Motion/Homing/FB_Homing.TcPOU
+++ b/POUs/Motion/Homing/FB_Homing.TcPOU
@@ -2,6 +2,7 @@
 <TcPlcObject Version="1.1.0.1">
   <POU Name="FB_Homing" Id="{b95d0b47-1221-0049-3c71-c4df2e544daa}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_Homing
+// Tested with Tc3_MC2_AdvancedHoming, 3.0.26.0
 VAR_IN_OUT
     Axis: Axis_Ref;
 END_VAR

--- a/VISUs/CoEParamTextList.TcTLO
+++ b/VISUs/CoEParamTextList.TcTLO
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.11">
+<TcPlcObject Version="1.1.0.1">
   <TextList Name="CoEParamTextList" Id="{4d9ffcd1-7a68-40dc-b979-fbaf840b8192}">
     <XmlArchive>
       <Data>


### PR DESCRIPTION
Fixes the bug which prevented the execution of a homing sequence towards a limit switch when starting the sequence on the limit switch.