### PR TITLE
Increase the initialization timer from 1 to 3 seconds

### DIFF
--- a/POUs/Pneumatics/FB_PneumaticAxis.TcPOU
+++ b/POUs/Pneumatics/FB_PneumaticAxis.TcPOU
@@ -30,7 +30,7 @@ VAR
 END_VAR
 ]]></Declaration>
     <Implementation>
-      <ST><![CDATA[tInitializeTimer(IN := bStartInitDelay, PT := T#1S);
+      <ST><![CDATA[tInitializeTimer(IN := bStartInitDelay, PT := T#3S);
 
 IF tInitializeTimer.Q THEN
     bStartInitDelay := FALSE;


### PR DESCRIPTION
In the attenuators application in BIFROST the initialization timer was not enough and I was starting with the error "No Bwd switch detected"
When the timer was increased to 3 seconds everything worked. This increase is due to the output that power the switches been activated after the pneumatic program runs.