### PR TITLE
Mbp 316 bug visu hw mask

### DIFF
--- a/VISUs/MainVisu.TcVIS
+++ b/VISUs/MainVisu.TcVIS
@@ -21137,7 +21137,7 @@ GVL.astAxes[Main.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                       <v>OnMouseClick</v>
                       <a cet="ToggleVarInputAction">
                         <o>
-                          <v n="ToggleVariable">"bLocalMode"</v>
+                          <v n="ToggleVariable">"GVL.astAxes[MAIN.hmiAxisSelection].stControl.bHWMaskActive"</v>
                           <n n="Error" />
                         </o>
                       </a>

--- a/VISUs/MainVisu.TcVIS
+++ b/VISUs/MainVisu.TcVIS
@@ -20482,7 +20482,7 @@ GVL.astAxes[Main.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                       <v>OnMouseClick</v>
                       <a cet="ToggleVarInputAction">
                         <o>
-                          <v n="ToggleVariable">"bLocalMode"</v>
+                          <v n="ToggleVariable">"GVL.bLocalMode"</v>
                           <n n="Error" />
                         </o>
                       </a>
@@ -20562,7 +20562,7 @@ GVL.astAxes[Main.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                         </o>
                         <o>
                           <v n="Id">743958181L</v>
-                          <v n="Value">"bLocalMode"</v>
+                          <v n="Value">"GVL.bLocalMode"</v>
                         </o>
                         <o>
                           <v n="Id">2597686782L</v>


### PR DESCRIPTION
The button in the MainVISU for the HW mask active was incorrectly linked to bLocalMode.
Now, on mouse click the variable ....stControl.bHWMaskActive is toggled.