### PR TITLE
Update version variables to v2.9.0 and update release notes

### DIFF
--- a/GVLs/GVL.TcGVL
+++ b/GVLs/GVL.TcGVL
@@ -5,7 +5,7 @@
     // Semantic version in machine-readable format.
     // Update it and commit it immediatly before setting a tag
     nVersionMajor: UINT := 2; // Major Version
-    nVersionMinor: UINT := 8; // Minor Version
+    nVersionMinor: UINT := 9; // Minor Version
     nVersionPatch: UINT := 0; // Patch level
 
     //Structure arrays for the axes

--- a/documentation/ReleaseNotes.txt
+++ b/documentation/ReleaseNotes.txt
@@ -18,6 +18,22 @@ which will reset the third digit to 0.
 The 3rd digit will be increased, when there is a pure bugfix.
 See v2.0.0 vs 2.0.1
 
+v2.9.0
+- New features:
+  - FB_Monitoring for all cabinet types at ESS (MBP-312).
+  - Add code to handle the temperature sensor hystersis. The motor will be disabled if the temperature
+	surpasses the defined Max Temperature, and it will not be able to be enabled until the value is
+	5 degrees less than the defined Max temperature (MBP-314).
+- Bug fix:
+  - Increase the initialization timer in FB_PneumaticAxis to avoid starting in error. Due
+    to the dealy between the Outpust for powering the swithces and running the PLC program
+	the Pneumatic axis used to start in error state because the Bwd limit switch was not found.
+  - Delete unused stranded grey box in the far right hand side of the MAIN Visu. This was discovered 
+    when scaling the MAIN Visu to be used in a web browser.
+  - In MAIN Visu correct the link of the HWMaskActive button. It was wrongly linked to the bLocalMode (MBP-316).
+  - Fix Homing bug, homing sequences did not start if axis was on a limit switch. All homing works now
+    even if the axis is on the limit switch (MBP-321).
+
 v2.8.0
 - New features:
   - Add buttons in MainVisu to enable and disable the soft limits (MBP-301).
@@ -44,7 +60,7 @@ v2.8.0
 - Bug fix:
   - Fix pneumatics starting displaying no State.
   - Fix when closing while Opening, it went to Error State.
-  - Remove any GVL_APP variables inside the FB_AxisPneuamtics so it can build without errors without 
+  - Remove any GVL_APP variables inside the FB_PneumaticAxis so it can build without errors without 
     the need of the correct tc_generic_structure variables (MBP-310).
   - Link bLocalMode and bHWMaskActive button in MainVisu to the corresponding GVL variable. 
 
@@ -53,7 +69,7 @@ v2.7.0
   - Backlash compensation: https://confluence.ess.eu/display/MCAG/Backlash+compensation (MBP-167).
   - Homing with two speeds (towards and from CAM) is the new default and only way of homing.
     This fixes the homing bug of bouncing against the limit non-stop (MBP-269, MBP-279, MBP-288).
-  - Add two status variables for detecting low and high pressure in FB_PneuamticAxis (MBP-297).
+  - Add two status variables for detecting low and high pressure in FB_PneumaticAxis (MBP-297).
   - Read and Write CoE parameters to a Beckhoff motor drive (MBP-271).
   - Improved comments for code and variables (MBP-257).
 - Bug fix:


### PR DESCRIPTION
Check variables in GVL correspond to the v2.9.0.
Check that all changes done after 2.8.0 have been included in the release notes under 2.9.0