### PR TITLE
Add logic for E-Stop LED

### DIFF
--- a/POUs/FB_ESSMonitoringMCU5001a.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU5001a.TcPOU
@@ -302,6 +302,7 @@ FOR i:=1 TO nMAX_ALARMS DO
         stMonitorLed.eErrorLED := aAlarmList[i].eErrorLED;
         stMonitorLed.eStatusLED := aAlarmList[i].eStatusLED;
         stMonitorLed.eAcknowledgeLED := aAlarmList[i].eAcknowledgeLED;
+        stMonitorLed.eEStopLED := aAlarmList[i].eEStopLED;
     END_IF
 END_FOR
 
@@ -332,6 +333,7 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
+bErrorLED := stMonitorLed.eEStopLED = E_MonitorLed.eSteady;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/FB_ESSMonitoringMCU5001a.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU5001a.TcPOU
@@ -302,7 +302,6 @@ FOR i:=1 TO nMAX_ALARMS DO
         stMonitorLed.eErrorLED := aAlarmList[i].eErrorLED;
         stMonitorLed.eStatusLED := aAlarmList[i].eStatusLED;
         stMonitorLed.eAcknowledgeLED := aAlarmList[i].eAcknowledgeLED;
-        stMonitorLed.eEStopLED := aAlarmList[i].eEStopLED;
     END_IF
 END_FOR
 
@@ -333,7 +332,7 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
-bErrorLED := stMonitorLed.eEStopLED = E_MonitorLed.eSteady;
+bErrorLED := NOT bEStop1Active;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/FB_ESSMonitoringMCU5001a.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU5001a.TcPOU
@@ -332,7 +332,7 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
-bErrorLED := NOT bEStop1Active;
+bEStopLED := NOT bEStop1Active;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/FB_ESSMonitoringMCU5001b.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU5001b.TcPOU
@@ -292,6 +292,7 @@ FOR i:=1 TO nMAX_ALARMS DO
         stMonitorLed.eErrorLED := aAlarmList[i].eErrorLED;
         stMonitorLed.eStatusLED := aAlarmList[i].eStatusLED;
         stMonitorLed.eAcknowledgeLED := aAlarmList[i].eAcknowledgeLED;
+        stMonitorLed.eEStopLED := aAlarmList[i].eEStopLED;
     END_IF
 END_FOR
 
@@ -322,6 +323,7 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
+bErrorLED := stMonitorLed.eEStopLED = E_MonitorLed.eSteady;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/FB_ESSMonitoringMCU5001b.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU5001b.TcPOU
@@ -292,7 +292,6 @@ FOR i:=1 TO nMAX_ALARMS DO
         stMonitorLed.eErrorLED := aAlarmList[i].eErrorLED;
         stMonitorLed.eStatusLED := aAlarmList[i].eStatusLED;
         stMonitorLed.eAcknowledgeLED := aAlarmList[i].eAcknowledgeLED;
-        stMonitorLed.eEStopLED := aAlarmList[i].eEStopLED;
     END_IF
 END_FOR
 
@@ -323,7 +322,7 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
-bErrorLED := stMonitorLed.eEStopLED = E_MonitorLed.eSteady;
+bErrorLED := NOT bEStop1Active;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/FB_ESSMonitoringMCU5001b.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU5001b.TcPOU
@@ -322,7 +322,7 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
-bErrorLED := NOT bEStop1Active;
+bEStopLED := NOT bEStop1Active;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/FB_ESSMonitoringMCU5002.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU5002.TcPOU
@@ -318,7 +318,7 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
-bErrorLED := NOT bEStop1Active;
+bEStopLED := NOT bEStop1Active;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/FB_ESSMonitoringMCU5002.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU5002.TcPOU
@@ -288,6 +288,7 @@ FOR i:=1 TO nMAX_ALARMS DO
         stMonitorLed.eErrorLED := aAlarmList[i].eErrorLED;
         stMonitorLed.eStatusLED := aAlarmList[i].eStatusLED;
         stMonitorLed.eAcknowledgeLED := aAlarmList[i].eAcknowledgeLED;
+        stMonitorLed.eEStopLED := aAlarmList[i].eEStopLED;
     END_IF
 END_FOR
 
@@ -318,6 +319,7 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
+bErrorLED := stMonitorLed.eEStopLED = E_MonitorLed.eSteady;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/FB_ESSMonitoringMCU5002.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU5002.TcPOU
@@ -288,7 +288,6 @@ FOR i:=1 TO nMAX_ALARMS DO
         stMonitorLed.eErrorLED := aAlarmList[i].eErrorLED;
         stMonitorLed.eStatusLED := aAlarmList[i].eStatusLED;
         stMonitorLed.eAcknowledgeLED := aAlarmList[i].eAcknowledgeLED;
-        stMonitorLed.eEStopLED := aAlarmList[i].eEStopLED;
     END_IF
 END_FOR
 
@@ -319,7 +318,7 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
-bErrorLED := stMonitorLed.eEStopLED = E_MonitorLed.eSteady;
+bErrorLED := NOT bEStop1Active;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/FB_ESSMonitoringMCU5003.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU5003.TcPOU
@@ -318,7 +318,7 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
-bErrorLED := NOT bEStop1Active;
+bEStopLED := NOT bEStop1Active;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/FB_ESSMonitoringMCU5003.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU5003.TcPOU
@@ -288,6 +288,7 @@ FOR i:=1 TO nMAX_ALARMS DO
         stMonitorLed.eErrorLED := aAlarmList[i].eErrorLED;
         stMonitorLed.eStatusLED := aAlarmList[i].eStatusLED;
         stMonitorLed.eAcknowledgeLED := aAlarmList[i].eAcknowledgeLED;
+        stMonitorLed.eEStopLED := aAlarmList[i].eEStopLED;
     END_IF
 END_FOR
 
@@ -318,6 +319,7 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
+bErrorLED := stMonitorLed.eEStopLED = E_MonitorLed.eSteady;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/FB_ESSMonitoringMCU5003.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU5003.TcPOU
@@ -288,7 +288,6 @@ FOR i:=1 TO nMAX_ALARMS DO
         stMonitorLed.eErrorLED := aAlarmList[i].eErrorLED;
         stMonitorLed.eStatusLED := aAlarmList[i].eStatusLED;
         stMonitorLed.eAcknowledgeLED := aAlarmList[i].eAcknowledgeLED;
-        stMonitorLed.eEStopLED := aAlarmList[i].eEStopLED;
     END_IF
 END_FOR
 
@@ -319,7 +318,7 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
-bErrorLED := stMonitorLed.eEStopLED = E_MonitorLed.eSteady;
+bErrorLED := NOT bEStop1Active;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/FB_ESSMonitoringMCU6001a.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU6001a.TcPOU
@@ -284,6 +284,7 @@ FOR i:=1 TO nMAX_ALARMS DO
         stMonitorLed.eErrorLED := aAlarmList[i].eErrorLED;
         stMonitorLed.eStatusLED := aAlarmList[i].eStatusLED;
         stMonitorLed.eAcknowledgeLED := aAlarmList[i].eAcknowledgeLED;
+        stMonitorLed.eEStopLED := aAlarmList[i].eEStopLED;
     END_IF
 END_FOR
 
@@ -314,6 +315,7 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
+bErrorLED := stMonitorLed.eEStopLED = E_MonitorLed.eSteady;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/FB_ESSMonitoringMCU6001a.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU6001a.TcPOU
@@ -284,7 +284,6 @@ FOR i:=1 TO nMAX_ALARMS DO
         stMonitorLed.eErrorLED := aAlarmList[i].eErrorLED;
         stMonitorLed.eStatusLED := aAlarmList[i].eStatusLED;
         stMonitorLed.eAcknowledgeLED := aAlarmList[i].eAcknowledgeLED;
-        stMonitorLed.eEStopLED := aAlarmList[i].eEStopLED;
     END_IF
 END_FOR
 
@@ -315,7 +314,7 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
-bErrorLED := stMonitorLed.eEStopLED = E_MonitorLed.eSteady;
+bErrorLED := NOT bEStop1Active;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/FB_ESSMonitoringMCU6001a.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU6001a.TcPOU
@@ -314,7 +314,7 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
-bErrorLED := NOT bEStop1Active;
+bEStopLED := NOT bEStop1Active;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/FB_ESSMonitoringMCU6001b.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU6001b.TcPOU
@@ -276,7 +276,6 @@ FOR i:=1 TO nMAX_ALARMS DO
         stMonitorLed.eErrorLED := aAlarmList[i].eErrorLED;
         stMonitorLed.eStatusLED := aAlarmList[i].eStatusLED;
         stMonitorLed.eAcknowledgeLED := aAlarmList[i].eAcknowledgeLED;
-        stMonitorLed.eEStopLED := aAlarmList[i].eEStopLED;
     END_IF
 END_FOR
 
@@ -307,7 +306,6 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
-bErrorLED := stMonitorLed.eEStopLED = E_MonitorLed.eSteady;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/FB_ESSMonitoringMCU6001b.TcPOU
+++ b/POUs/FB_ESSMonitoringMCU6001b.TcPOU
@@ -276,6 +276,7 @@ FOR i:=1 TO nMAX_ALARMS DO
         stMonitorLed.eErrorLED := aAlarmList[i].eErrorLED;
         stMonitorLed.eStatusLED := aAlarmList[i].eStatusLED;
         stMonitorLed.eAcknowledgeLED := aAlarmList[i].eAcknowledgeLED;
+        stMonitorLed.eEStopLED := aAlarmList[i].eEStopLED;
     END_IF
 END_FOR
 
@@ -306,6 +307,7 @@ bAcknowledgeLED :=
     (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSteady)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eFast AND fbFastBlinkOn.Q)
     OR (stMonitorLed.eAcknowledgeLED = E_MonitorLed.eSlow AND fbSlowBlinkOn.Q);
+bErrorLED := stMonitorLed.eEStopLED = E_MonitorLed.eSteady;
 ]]></ST>
       </Implementation>
     </Method>


### PR DESCRIPTION
Add the logic to turn on and off th eE-Stop LED when the E-Stop is active in all cabinet monitoring FBs.

modified:   POUs/FB_ESSMonitoringMCU5001a.TcPOU
modified:   POUs/FB_ESSMonitoringMCU5001b.TcPOU
modified:   POUs/FB_ESSMonitoringMCU5002.TcPOU
modified:   POUs/FB_ESSMonitoringMCU5003.TcPOU
modified:   POUs/FB_ESSMonitoringMCU6001a.TcPOU
modified:   POUs/FB_ESSMonitoringMCU6001b.TcPOU