### PR TITLE
MBP-406: Improvement to reworked homing

### DIFF
--- a/DUTs/Axis_Structures/ST_HomingConfig.TcDUT
+++ b/DUTs/Axis_Structures/ST_HomingConfig.TcDUT
@@ -4,16 +4,17 @@
     <Declaration><![CDATA[TYPE ST_HomingConfig :
 STRUCT
     //Hardware signals
-    eDetectionMode: E_DetectionMode := E_DetectionMode.eRising; //Homing signal detection mode (only valid for routines home to limit and ref)
+    bLimitFwdNormallyClosed: BOOL := TRUE; //Forward limit switch is normally closed
+    bLimitBwdNormallyClosed: BOOL := TRUE; //Backward limit switch is normally closed
+    bHomeSensorNormallyClosed: BOOL := FALSE; //Home sensor signal is normally closed
 
     //General Advanced Homing Configuration
     bDisableDriveAccess: BOOL := TRUE; //Disables the drive access to drives. TRUE when using stepper motors. If supported in drive, can be set to FALSE, e.g. for AX5106.
-    bEnableLagErrorDetection :BOOL := TRUE; //Keeps the lag error detection active during homing
-    bInstantLagReduction :BOOL := FALSE; //(belongs to Option4) When referencing to a mechanical fixed stop, the lag error is dissipated abruptly by setting this flag.
+    bEnableLagErrorDetection: BOOL := TRUE; //Keeps the lag error detection active during homing
+    bInstantLagReduction: BOOL := FALSE; //(belongs to Option4) When referencing to a mechanical fixed stop, the lag error is dissipated abruptly by setting this flag.
     tTimeLimit: TIME; //Exceeding this time leads to the search procedure being aborted.
     fDistanceLimit: LREAL; //Distance limit for homing; exceeding this from the start position aborts the procedure
     fTorqueLimit: LREAL; //Torque limit to prevent mechanical damage
-
 
     //Homing Configuration for Step Block
     fDetectionVelocityLimit: LREAL; //Velocity threshold to detect a fixed stop within the specified time

--- a/DUTs/Axis_Structures/ST_HomingConfig.TcDUT
+++ b/DUTs/Axis_Structures/ST_HomingConfig.TcDUT
@@ -4,6 +4,7 @@
     <Declaration><![CDATA[TYPE ST_HomingConfig :
 STRUCT
     //Hardware signals
+    eDetectionMode: E_DetectionMode := E_DetectionMode.eFalling; //Homing signal detection mode (only valid for routines home to limit and ref)
     bLimitFwdNormallyClosed: BOOL := TRUE; //Forward limit switch is normally closed
     bLimitBwdNormallyClosed: BOOL := TRUE; //Backward limit switch is normally closed
     bHomeSensorNormallyClosed: BOOL := FALSE; //Home sensor signal is normally closed

--- a/DUTs/Axis_Structures/ST_HomingConfig.TcDUT
+++ b/DUTs/Axis_Structures/ST_HomingConfig.TcDUT
@@ -21,6 +21,9 @@ STRUCT
     fDetectionVelocityLimit: LREAL; //Velocity threshold to detect a fixed stop within the specified time
     tDetectionVelocityTime: TIME; //Time duration to detect velocity drop at a fixed stop
     fLagLimit: LREAL; //Lag limit value for detecting a fixed stop
+
+    //Finish Homing
+    bAbsoluteMoveAtFinishHoming: BOOL := FALSE; //When set to TRUE the fHomeFinishDistance is used as absolute move
 END_STRUCT
 END_TYPE
 ]]></Declaration>

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -728,7 +728,7 @@ fbHome(
     bLimitBwd := _stAxis.stInputs.bLimitBwd,
     bLimitFwd := _stAxis.stInputs.bLimitFwd,
     bHomeSensor := _stAxis.stInputs.bHomeSensor,
-    stConfig := _stAxis.stConfig);
+    stConfig := _stAxis.stConfig.stHomingConfig);
 fbHome.bExecute := FALSE;
 
 mControl_Home.Busy := fbHome.bBusy;

--- a/POUs/Motion/Homing/FB_Homing.TcPOU
+++ b/POUs/Motion/Homing/FB_Homing.TcPOU
@@ -36,7 +36,6 @@ VAR
     eSelectedDirection: (eFORWARD, eBACKWARD);
 
     eCurrentDirection: MC_Home_Direction; //Current direction used during homing execution
-    eCurrentReversedDirection: MC_Home_Direction; //Current reversed direction used during homing execution
     eCurrentDetectionMode: E_DetectionMode; //Current detection mode used during homing execution
 
     eCoarseSwitchMode: MC_Switch_Mode; //Switch mode used for coarse detection
@@ -106,6 +105,7 @@ mStateMachine(Axis := Axis);
 mOutputs();
 ]]></ST>
     </Implementation>
+    <Folder Name="Direction" Id="{cf6380c9-04e0-0f85-0ee0-78c7c4234fb4}" />
     <Folder Name="Initialization" Id="{a4834b0c-5a39-0343-1840-cdfcbbfa1e02}" />
     <Folder Name="StateMachine" Id="{5850658b-ad43-095c-267a-69fea0de8d61}" />
     <Method Name="mCalcToRefDirection" Id="{ea329024-e768-02c9-1e7d-fe6d98db5ff1}" FolderPath="Direction\">
@@ -262,7 +262,7 @@ CASE eSelectedHomingRoutine OF
             Axis := Axis,
             Execute := (eHomingSpeed = eCOARSE) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
             Parameter := stHomingParameter,
-            Direction := eCurrentReversedDirection,
+            Direction := mReverseDirection(eCurrentDirection),
             TimeLimit :=  stConfig.tTimeLimit,
             DistanceLimit := stConfig.fDistanceLimit,
             TorqueLimit := stConfig.fTorqueLimit, //The motor torque is limited to this value (percentage of configured channel peak torque), in relation to the weight counterbalance that is possibly parameterized in the drive, in order to avoid mechanical damage.
@@ -602,10 +602,8 @@ END_CASE
 //Set current MC_Home_Directions based on selected direction
 IF eSelectedDirection = eFORWARD THEN
     eCurrentDirection := MC_Home_Direction.mcPositiveDirection;
-    eCurrentReversedDirection := MC_Home_Direction.mcNegativeDirection;
 ELSE
     eCurrentDirection := MC_Home_Direction.mcNegativeDirection;
-    eCurrentReversedDirection := MC_Home_Direction.mcPositiveDirection;
 END_IF
 ]]></ST>
       </Implementation>
@@ -696,6 +694,26 @@ bError := eHomingState = E_HomeSequenceState.eError;
 IF nErrorID <> 0 AND nErrorState = 0 THEN
     nErrorState := eHomingState;
 END_IF
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="mReverseDirection" Id="{904e6f2e-c1ef-0e35-10b8-2390dc58726b}" FolderPath="Direction\">
+      <Declaration><![CDATA[METHOD PRIVATE mReverseDirection : MC_Home_Direction
+VAR_INPUT
+    eDirection: MC_Home_Direction;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[CASE eDirection OF
+    MC_Home_Direction.mcNegativeDirection:
+        mReverseDirection := MC_Home_Direction.mcPositiveDirection;
+    MC_Home_Direction.mcPositiveDirection:
+        mReverseDirection := MC_Home_Direction.mcNegativeDirection;
+    MC_Home_Direction.mcSwitchNegative:
+        mReverseDirection := MC_Home_Direction.mcSwitchPositive;
+    MC_Home_Direction.mcSwitchPositive:
+        mReverseDirection := MC_Home_Direction.mcSwitchNegative;
+END_CASE
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/Motion/Homing/FB_Homing.TcPOU
+++ b/POUs/Motion/Homing/FB_Homing.TcPOU
@@ -51,6 +51,7 @@ VAR
     //Step functions
     fbStepLimitSwitch: MC_StepLimitSwitch;
     fbStepLimitSwitchDetection: MC_StepLimitSwitchDetection;
+    fbStepAbsoluteSwitch: MC_StepAbsoluteSwitch;
     fbStepAbsoluteSwitchDetection: MC_StepAbsoluteSwitchDetection;
     fbStepReferencePulse: MC_StepReferencePulse;
     fbStepBlockLag: MC_StepBlockLagBased;
@@ -107,6 +108,40 @@ mOutputs();
     </Implementation>
     <Folder Name="Initialization" Id="{a4834b0c-5a39-0343-1840-cdfcbbfa1e02}" />
     <Folder Name="StateMachine" Id="{5850658b-ad43-095c-267a-69fea0de8d61}" />
+    <Method Name="mCalcToRefDirection" Id="{ea329024-e768-02c9-1e7d-fe6d98db5ff1}" FolderPath="Direction\">
+      <Declaration><![CDATA[METHOD PRIVATE mCalcToRefDirection : MC_Home_Direction
+VAR_INPUT
+    eDirection: MC_Home_Direction;
+    eDetection: E_DetectionMode;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[CASE eDetection OF
+    //Fastest exection is with using switch direction variant
+    E_DetectionMode.eRising:
+        CASE eDirection OF
+            MC_Home_Direction.mcNegativeDirection:
+                mCalcToRefDirection := MC_Home_Direction.mcSwitchNegative;
+            MC_Home_Direction.mcPositiveDirection:
+                mCalcToRefDirection := MC_Home_Direction.mcSwitchPositive;
+            ELSE
+                mCalcToRefDirection := eDirection;
+        END_CASE
+
+    //Fastest exection is with using normal direction variant
+    E_DetectionMode.eFalling:
+        CASE eDirection OF
+            MC_Home_Direction.mcSwitchNegative:
+                mCalcToRefDirection := MC_Home_Direction.mcNegativeDirection;
+            MC_Home_Direction.mcSwitchPositive:
+                mCalcToRefDirection := MC_Home_Direction.mcPositiveDirection;
+            ELSE
+                mCalcToRefDirection := eDirection;
+        END_CASE
+END_CASE
+]]></ST>
+      </Implementation>
+    </Method>
     <Method Name="mCallFunctionBlocks" Id="{9a2a738b-1099-0643-0d66-9fbff7e594f9}">
       <Declaration><![CDATA[METHOD PRIVATE mCallFunctionBlocks
 VAR_IN_OUT
@@ -198,17 +233,18 @@ CASE eSelectedHomingRoutine OF
             Error => bCoarseError,
             ErrorID => nCoarseErrorID);
 
-        //Using StepLimitSwitch over StepAbsoluteSwitch to reduce the movement
-        fbStepLimitSwitch(
+        fbStepAbsoluteSwitch(
             Axis := Axis,
             Execute := (eHomingSpeed = eFINE) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
             Parameter := stHomingParameter,
-            Direction := eCurrentDirection,
-            TimeLimit :=  stConfig.stHomingConfig.tTimeLimit,
-            DistanceLimit := stConfig.stHomingConfig.fDistanceLimit,
-            TorqueLimit := stConfig.stHomingConfig.fTorqueLimit, //The motor torque is limited to this value (percentage of configured channel peak torque), in relation to the weight counterbalance that is possibly parameterized in the drive, in order to avoid mechanical damage.
-            LimitSwitchMode := eFineSwitchMode,
-            LimitSwitchSignal := stRefSwitchSignal,
+            Direction := mCalcToRefDirection(eCurrentDirection, eCurrentDetectionMode),
+            TimeLimit :=  stConfig.tTimeLimit,
+            DistanceLimit := stConfig.fDistanceLimit,
+            TorqueLimit := stConfig.fTorqueLimit, //The motor torque is limited to this value (percentage of configured channel peak torque), in relation to the weight counterbalance that is possibly parameterized in the drive, in order to avoid mechanical damage.
+            SwitchMode := eFineSwitchMode,
+            ReferenceSignal := stRefSwitchSignal,
+            PositiveLimitSwitch := bLimitSwitchFwdPressed,
+            NegativeLimitSwitch := bLimitSwitchBwdPressed,
             Velocity := fVelocityFromCam,
             SetPosition := fHomePosition,
             Options := stOptions,

--- a/POUs/Motion/Homing/FB_Homing.TcPOU
+++ b/POUs/Motion/Homing/FB_Homing.TcPOU
@@ -30,10 +30,10 @@ END_VAR
 
 VAR
     eHomingState: E_HomeSequenceState := E_HomeSequenceState.eWaitForExecute;
-    eHomingSpeed: (eDISABLED, eCOARSE, eFINE);
+    eHomingSpeed: (eDisabled, eCoarse, eFine);
 
-    eSelectedHomingRoutine: (eNO_HOMING := 0, eTO_LIMIT := 1, eTO_REF := 11, eTO_ENC_PULSE := 21, eTO_ENC_PULSE_VIA_LIMIT := 23, eTO_BLOCK := 30, eDIRECT := 90);
-    eSelectedDirection: (eFORWARD, eBACKWARD);
+    eSelectedHomingRoutine: (eNoHoming := 0, eToLimit := 1, eToRef := 11, eToEncPulse := 21, eToEncPulseViaLimit := 23, eToBlock := 30, eDirect := 90);
+    eSelectedDirection: (eForward, eBackward);
 
     eCurrentDirection: MC_Home_Direction; //Current direction used during homing execution
     eCurrentDetectionMode: E_DetectionMode; //Current detection mode used during homing execution
@@ -176,11 +176,11 @@ IF NOT fbVelocityFromCam.Error THEN
 END_IF
 
 CASE eSelectedHomingRoutine OF
-    eTO_LIMIT:
+    eToLimit:
 
         fbStepLimitSwitchDetection(
             Axis := Axis,
-            Execute := (eHomingSpeed = eCOARSE) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
+            Execute := (eHomingSpeed = eCoarse) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
             Parameter := stHomingParameter,
             Direction := eCurrentDirection,
             TimeLimit :=  stConfig.tTimeLimit,
@@ -198,7 +198,7 @@ CASE eSelectedHomingRoutine OF
 
         fbStepLimitSwitch(
             Axis := Axis,
-            Execute := (eHomingSpeed = eFINE) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
+            Execute := (eHomingSpeed = eFine) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
             Parameter := stHomingParameter,
             Direction := eCurrentDirection,
             TimeLimit :=  stConfig.tTimeLimit,
@@ -215,11 +215,11 @@ CASE eSelectedHomingRoutine OF
             Error => bFineError,
             ErrorID => nFineErrorID);
 
-    eTO_REF:
+    eToRef:
 
         fbStepAbsoluteSwitchDetection(
             Axis := Axis,
-            Execute := (eHomingSpeed = eCOARSE) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
+            Execute := (eHomingSpeed = eCoarse) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
             Parameter := stHomingParameter,
             Direction := eCurrentDirection,
             TimeLimit :=  stConfig.tTimeLimit,
@@ -239,7 +239,7 @@ CASE eSelectedHomingRoutine OF
 
         fbStepAbsoluteSwitch(
             Axis := Axis,
-            Execute := (eHomingSpeed = eFINE) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
+            Execute := (eHomingSpeed = eFine) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
             Parameter := stHomingParameter,
             Direction := mCalcToRefDirection(eCurrentDirection, eCurrentDetectionMode),
             TimeLimit :=  stConfig.tTimeLimit,
@@ -258,13 +258,13 @@ CASE eSelectedHomingRoutine OF
             Error => bFineError,
             ErrorID => nFineErrorID);
 
-    eTO_ENC_PULSE,
-    eTO_ENC_PULSE_VIA_LIMIT:
+    eToEncPulse,
+    eToEncPulseViaLimit:
 
        //Reversed movement, uses reversed signals (eCurrentReversedDirection and stReversedLimitSwitchSignal)
        fbStepLimitSwitchDetection(
             Axis := Axis,
-            Execute := (eHomingSpeed = eCOARSE) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
+            Execute := (eHomingSpeed = eCoarse) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
             Parameter := stHomingParameter,
             Direction := mReverseDirection(eCurrentDirection),
             TimeLimit :=  stConfig.tTimeLimit,
@@ -282,7 +282,7 @@ CASE eSelectedHomingRoutine OF
 
         fbStepReferencePulse(
             Axis := Axis,
-            Execute := (eHomingSpeed = eFINE) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
+            Execute := (eHomingSpeed = eFine) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
             Parameter := stHomingParameter,
             Direction := eCurrentDirection,
             TimeLimit :=  stConfig.tTimeLimit,
@@ -298,11 +298,11 @@ CASE eSelectedHomingRoutine OF
             Error => bFineError,
             ErrorID => nFineErrorID);
 
-    eTO_BLOCK:
+    eToBlock:
 
         fbStepBlockLag(
             Axis := Axis,
-            Execute := (eHomingSpeed = eFINE) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
+            Execute := (eHomingSpeed = eFine) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
             Parameter := stHomingParameter,
             Direction := eCurrentDirection,
             Velocity := fVelocityFromCam,
@@ -387,8 +387,8 @@ END_VAR
 
     E_HomeSequenceState.eFinishDetection:
         //Repeat execution with fine detection
-        IF eHomingSpeed = eCOARSE THEN
-            eHomingSpeed := eFINE;
+        IF eHomingSpeed = eCoarse THEN
+            eHomingSpeed := eFine;
             eHomingState := E_HomeSequenceState.eInitDetetion;
             RETURN;
         END_IF
@@ -501,18 +501,18 @@ END_VAR
 //otherwise it will result in CommandAborted on hitting the sensor
 CASE eSelectedHomingRoutine OF
 
-    eTO_LIMIT:
+    eToLimit:
         bCoarseEnable := TRUE;
         bFineEnable := TRUE;
 
-    eTO_ENC_PULSE_VIA_LIMIT:
+    eToEncPulseViaLimit:
         bCoarseDirectionReversed := TRUE;
         bCoarseEnable := TRUE;
 
 END_CASE
 
 //Only enable in the direction of the homing movement
-IF eSelectedDirection = eFORWARD THEN
+IF eSelectedDirection = eForward THEN
     bCoarseEnablePositive := bCoarseEnable AND NOT bCoarseDirectionReversed;
     bFineEnablePositive := bFineEnable;
 
@@ -533,17 +533,17 @@ END_IF
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[CASE eSelectedHomingRoutine OF
-    eTO_LIMIT,
-    eTO_REF,
-    eTO_ENC_PULSE_VIA_LIMIT:
-        eHomingSpeed := eCOARSE;
+    eToLimit,
+    eToRef,
+    eToEncPulseViaLimit:
+        eHomingSpeed := eCoarse;
 
-    eTO_ENC_PULSE,
-    eTO_BLOCK:
-        eHomingSpeed := eFINE;
+    eToEncPulse,
+    eToBlock:
+        eHomingSpeed := eFine;
 
     ELSE
-        eHomingSpeed := eDISABLED;
+        eHomingSpeed := eDisabled;
 END_CASE
 ]]></ST>
       </Implementation>
@@ -555,54 +555,54 @@ END_CASE
         <ST><![CDATA[//Splitting directional information and routine state of E_HomingRoutines
 CASE eHomingRoutine OF
     E_HomingRoutines.eNoHoming:
-        eSelectedHomingRoutine := eNO_HOMING;
+        eSelectedHomingRoutine := eNoHoming;
 
     E_HomingRoutines.eHomeToLimit_Bwd:
-        eSelectedDirection := eBACKWARD;
-        eSelectedHomingRoutine := eTO_LIMIT;
+        eSelectedDirection := eBackward;
+        eSelectedHomingRoutine := eToLimit;
 
     E_HomingRoutines.eHomeToLimit_Fwd:
-        eSelectedDirection := eFORWARD;
-        eSelectedHomingRoutine := eTO_LIMIT;
+        eSelectedDirection := eForward;
+        eSelectedHomingRoutine := eToLimit;
 
     E_HomingRoutines.eHomeToRef_Bwd:
-        eSelectedDirection := eBACKWARD;
-        eSelectedHomingRoutine := eTO_REF;
+        eSelectedDirection := eBackward;
+        eSelectedHomingRoutine := eToRef;
 
     E_HomingRoutines.eHomeToRef_Fwd:
-        eSelectedDirection := eFORWARD;
-        eSelectedHomingRoutine := eTO_REF;
+        eSelectedDirection := eForward;
+        eSelectedHomingRoutine := eToRef;
 
     E_HomingRoutines.eHomeToEncPulse_Bwd:
-        eSelectedDirection := eBACKWARD;
-        eSelectedHomingRoutine := eTO_ENC_PULSE;
+        eSelectedDirection := eBackward;
+        eSelectedHomingRoutine := eToEncPulse;
 
     E_HomingRoutines.eHomeToEncPulse_Fwd:
-        eSelectedDirection := eFORWARD;
-        eSelectedHomingRoutine := eTO_ENC_PULSE;
+        eSelectedDirection := eForward;
+        eSelectedHomingRoutine := eToEncPulse;
 
     E_HomingRoutines.eHomeToEncPulse_viaBwdLimit:
-        eSelectedDirection := eFORWARD; //Forward Pulse + Backward Limit Touch
-        eSelectedHomingRoutine := eTO_ENC_PULSE_VIA_LIMIT;
+        eSelectedDirection := eForward; //Forward Pulse + Backward Limit Touch
+        eSelectedHomingRoutine := eToEncPulseViaLimit;
 
     E_HomingRoutines.eHomeToEncPulse_viaFwdLimit:
-        eSelectedDirection := eBACKWARD; //Backward Pulse + Forward Limit Touch
-        eSelectedHomingRoutine := eTO_ENC_PULSE_VIA_LIMIT;
+        eSelectedDirection := eBackward; //Backward Pulse + Forward Limit Touch
+        eSelectedHomingRoutine := eToEncPulseViaLimit;
 
     E_HomingRoutines.eHomeToBlock_Bwd:
-        eSelectedDirection := eBACKWARD;
-        eSelectedHomingRoutine := eTO_BLOCK;
+        eSelectedDirection := eBackward;
+        eSelectedHomingRoutine := eToBlock;
 
     E_HomingRoutines.eHomeToBlock_Fwd:
-        eSelectedDirection := eFORWARD;
-        eSelectedHomingRoutine := eTO_BLOCK;
+        eSelectedDirection := eForward;
+        eSelectedHomingRoutine := eToBlock;
 
     E_HomingRoutines.eHomeDirect:
-        eSelectedHomingRoutine := eDIRECT;
+        eSelectedHomingRoutine := eDirect;
 END_CASE
 
 //Set current MC_Home_Directions based on selected direction
-IF eSelectedDirection = eFORWARD THEN
+IF eSelectedDirection = eForward THEN
     eCurrentDirection := MC_Home_Direction.mcPositiveDirection;
 ELSE
     eCurrentDirection := MC_Home_Direction.mcNegativeDirection;
@@ -682,12 +682,12 @@ bExecutingDetection := (eHomingState >= E_HomeSequenceState.eInitDetetion)
                     AND (eHomingState <= E_HomeSequenceState.eFinishDetection);
 
 bEnablePositive := bExecutingDetection
-                AND ((bCoarseEnablePositive AND eHomingSpeed = eCOARSE)
-                    OR (bFineEnablePositive AND eHomingSpeed = eFINE));
+                AND ((bCoarseEnablePositive AND eHomingSpeed = eCoarse)
+                    OR (bFineEnablePositive AND eHomingSpeed = eFine));
 
 bEnableNegative := bExecutingDetection
-                AND ((bCoarseEnableNegative AND eHomingSpeed = eCOARSE)
-                    OR (bFineEnableNegative AND eHomingSpeed = eFINE));
+                AND ((bCoarseEnableNegative AND eHomingSpeed = eCoarse)
+                    OR (bFineEnableNegative AND eHomingSpeed = eFine));
 
 bError := eHomingState = E_HomeSequenceState.eError;
 IF nErrorID <> 0 AND nErrorState = 0 THEN
@@ -739,9 +739,9 @@ END_VAR
 
     E_HomeSequenceState.eSelectDetection:
         CASE eSelectedHomingRoutine OF
-            eNO_HOMING:
+            eNoHoming:
                 eHomingState := E_HomeSequenceState.eDone;
-            eDIRECT:
+            eDirect:
                 eHomingState := E_HomeSequenceState.eHomeDirect;
             ELSE
                 eHomingState := E_HomeSequenceState.eInitDetetion;
@@ -751,7 +751,7 @@ END_VAR
 
     E_HomeSequenceState.eInitDetetion..E_HomeSequenceState.eFinishDetection:
         CASE eHomingSpeed OF
-            eCOARSE:
+            eCoarse:
                 mExecuteHoming(
                     Axis := Axis,
                     bBusy := bCoarseBusy,
@@ -759,7 +759,7 @@ END_VAR
                     bCommandAborted := bCoarseCommandAborted,
                     bError := bCoarseError,
                     nErrorID := nCoarseErrorID);
-            eFINE:
+            eFine:
                 mExecuteHoming(
                     Axis := Axis,
                     bBusy := bFineBusy,

--- a/POUs/Motion/Homing/FB_Homing.TcPOU
+++ b/POUs/Motion/Homing/FB_Homing.TcPOU
@@ -473,6 +473,9 @@ END_CASE
             ELSE
                 eHomingState := E_HomeSequenceState.eCommandAborted;
             END_IF
+
+            //Fix issue CommandAborted output of MC_AbortHoming stays TRUE once its set
+            MEMSET(destAddr:=ADR(fbAbortHoming.CommandAborted), fillByte:=0, n:=SIZEOF(fbAbortHoming.CommandAborted));
         END_IF
 
 END_CASE

--- a/POUs/Motion/Homing/FB_Homing.TcPOU
+++ b/POUs/Motion/Homing/FB_Homing.TcPOU
@@ -8,9 +8,9 @@ VAR_IN_OUT
 END_VAR
 VAR_INPUT
     bExecute: BOOL;
-    bLimitFwd: BOOL;
-    bLimitBwd: BOOL;
-    bHomeSensor: BOOL;
+    bLimitFwd: BOOL; //Forward limit switch
+    bLimitBwd: BOOL; //Backward limit switch
+    bHomeSensor: BOOL; //Home sensor signal
     eHomingRoutine: E_HomingRoutines := E_HomingRoutines.eNoHoming;
     fHomePosition: LREAL;
     fHomeFinishDistance: LREAL;
@@ -21,8 +21,8 @@ VAR_OUTPUT
     bBusy: BOOL;
     bActive: BOOL;
     bCommandAborted: BOOL;
-    bEnablePositive: BOOL;
-    bEnableNegative: BOOL;
+    bEnablePositive: BOOL; //Request power enable positive during homing execution
+    bEnableNegative: BOOL; //Request power enable negative during homing execution
     bError: BOOL;
     nErrorID: UDINT;
     nErrorState: UINT;
@@ -74,10 +74,10 @@ VAR
     nFineErrorID: UDINT;
 
     //Enable override
-    bCoarseEnablePositive: BOOL; //Enable override during coarse stage in positive direction (forward)
-    bCoarseEnableNegative: BOOL; //Enable override during coarse stage in negative direction (backward)
-    bFineEnablePositive: BOOL; //Enable override during fine stage in positive direction (forward)
-    bFineEnableNegative: BOOL; //Enable override during fine stage in negative direction (backward)
+    bCoarseEnablePositive: BOOL; //Request power enable positive (forward), during coarse stage
+    bCoarseEnableNegative: BOOL; //Request power enable negative (backward), during coarse stage
+    bFineEnablePositive: BOOL; //Request power enable positive (forward), during fine stage
+    bFineEnableNegative: BOOL; //Request power enable positive (backward), during fine stage
 
     //Finalizing functions
     fbHomeDirect: MC_HomeDirect;

--- a/POUs/Motion/Homing/FB_Homing.TcPOU
+++ b/POUs/Motion/Homing/FB_Homing.TcPOU
@@ -98,8 +98,8 @@ VAR
 END_VAR
 
 VAR CONSTANT
-    nERROR_ABORT_HOMING: UDINT := 16#E5501; //Drive parameters were not restored aftor homing
-    nERROR_POWER_DISABLED: UDINT := 16#E5502; //Power was disabled during homing procedure
+    nERROR_ABORT_HOMING: UDINT := 16#4B9F; //The abortion of a homing has failed. https://infosys.beckhoff.com/english.php?content=../content/1033/tcncerrcode2/513151243.html
+    nERROR_POWER_DISABLED: UDINT := 16#4650; //Drive hardware not ready to operate. https://infosys.beckhoff.com/english.php?content=../content/1033/tcncerrcode2/4670612235.html
 END_VAR
 ]]></Declaration>
     <Implementation>

--- a/POUs/Motion/Homing/FB_Homing.TcPOU
+++ b/POUs/Motion/Homing/FB_Homing.TcPOU
@@ -482,31 +482,27 @@ END_CASE
     <Method Name="mInitEnable" Id="{d3639741-5d83-088b-3be0-aaffdae6ce64}" FolderPath="Initialization\">
       <Declaration><![CDATA[METHOD PRIVATE mInitEnable
 VAR
-    bCoarseEnable: BOOL := TRUE;
-    bFineEnable: BOOL := TRUE;
+    bCoarseEnable: BOOL := FALSE;
+    bFineEnable: BOOL := FALSE;
     bCoarseDirectionReversed: BOOL := FALSE;
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[//Disable enable override based on coarse/fine homing speed
+        <ST><![CDATA[//Request power enable negative/positive, if the selected homing routine uses StepLimitSwitch,
+//otherwise it will result in CommandAborted on hitting the sensor
 CASE eSelectedHomingRoutine OF
-    //1. During eTO_REF in fine stage no mechanical limit switches should be hit
-    eTO_REF:
-        bFineEnable := FALSE;
 
-    //2. No enable override required during execution
-    eTO_ENC_PULSE,
-    eTO_BLOCK:
-        bCoarseEnable := FALSE;
-        bFineEnable := FALSE;
+    eTO_LIMIT:
+        bCoarseEnable := TRUE;
+        bFineEnable := TRUE;
 
-    //3. During coarse stage the direction is reversed and no enable in fine stage
     eTO_ENC_PULSE_VIA_LIMIT:
         bCoarseDirectionReversed := TRUE;
-        bFineEnable := FALSE;
+        bCoarseEnable := TRUE;
 
 END_CASE
 
+//Only enable in the direction of the homing movement
 IF eSelectedDirection = eFORWARD THEN
     bCoarseEnablePositive := bCoarseEnable AND NOT bCoarseDirectionReversed;
     bFineEnablePositive := bFineEnable;

--- a/POUs/Motion/Homing/FB_Homing.TcPOU
+++ b/POUs/Motion/Homing/FB_Homing.TcPOU
@@ -41,6 +41,10 @@ VAR
     eCoarseSwitchMode: MC_Switch_Mode; //Switch mode used for coarse detection
     eFineSwitchMode: MC_Switch_Mode; //Switch mode used for fine detection
 
+    bLimitSwitchFwdPressed: BOOL; //Forward limit switch signal is actively engaged / pressed
+    bLimitSwitchBwdPressed: BOOL; //Backward limit switch is actively engaged / pressed
+    bHomeSensorEngaged: BOOL; //Homing sensor is actively detects presence / engaged / pressed
+
     //Hardware Signals
     stLimitSwitchSignal: MC_Ref_Signal_Ref := (SignalSource := SignalSource_Default, TouchProbe := PlcEvent);
     stReversedLimitSwitchSignal: MC_Ref_Signal_Ref := (SignalSource := SignalSource_Default, TouchProbe := PlcEvent);
@@ -223,8 +227,8 @@ CASE eSelectedHomingRoutine OF
             TorqueLimit := stConfig.fTorqueLimit, //The motor torque is limited to this value (percentage of configured channel peak torque), in relation to the weight counterbalance that is possibly parameterized in the drive, in order to avoid mechanical damage.
             SwitchMode := eCoarseSwitchMode,
             ReferenceSignal := stRefSwitchSignal,
-            PositiveLimitSwitch := NOT(bLimitFwd),
-            NegativeLimitSwitch := NOT(bLimitBwd),
+            PositiveLimitSwitch := bLimitSwitchFwdPressed,
+            NegativeLimitSwitch := bLimitSwitchBwdPressed,
             Velocity := fVelocityToCam,
             Options := stOptions,
             Done => bCoarseDone,
@@ -637,22 +641,27 @@ END_CASE
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[//Options for common function blocks used for all routines
-stOptions.DisableDriveAccess := stConfig.stHomingConfig.bDisableDriveAccess;
-stOptions.EnableLagErrorDetection := stConfig.stHomingConfig.bEnableLagErrorDetection;
+stOptions.DisableDriveAccess := stConfig.bDisableDriveAccess;
+stOptions.EnableLagErrorDetection := stConfig.bEnableLagErrorDetection;
 
 //Options for StepBlockLagDetection
-stOptions3.DisableDriveAccess := stConfig.stHomingConfig.bDisableDriveAccess;
-stOptions3.InstantLagReduction := stConfig.stHomingConfig.bInstantLagReduction;
+stOptions3.DisableDriveAccess := stConfig.bDisableDriveAccess;
+stOptions3.InstantLagReduction := stConfig.bInstantLagReduction;
 
-//Reference signal
+//Check normal closed state of homing signals
+bLimitSwitchFwdPressed := bLimitFwd XOR stConfig.bLimitFwdNormallyClosed;
+bLimitSwitchBwdPressed := bLimitBwd XOR stConfig.bLimitBwdNormallyClosed;
+bHomeSensorEngaged := bHomeSensor XOR stConfig.bHomeSensorNormallyClosed;
+
+//Update signal ref
 IF eCurrentDirection = MC_Home_Direction.mcPositiveDirection THEN
-    stLimitSwitchSignal.Level := NOT(bLimitFwd);
-    stReversedLimitSwitchSignal.Level := NOT(bLimitBwd);
+    stLimitSwitchSignal.Level := bLimitSwitchFwdPressed;
+    stReversedLimitSwitchSignal.Level := bLimitSwitchBwdPressed;
 ELSE
-    stLimitSwitchSignal.Level := NOT(bLimitBwd);
-    stReversedLimitSwitchSignal.Level := NOT(bLimitFwd);
+    stLimitSwitchSignal.Level := bLimitSwitchBwdPressed;
+    stReversedLimitSwitchSignal.Level := bLimitSwitchFwdPressed;
 END_IF
-stRefSwitchSignal.Level := bHomeSensor;
+stRefSwitchSignal.Level := bHomeSensorEngaged;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/Motion/Homing/FB_Homing.TcPOU
+++ b/POUs/Motion/Homing/FB_Homing.TcPOU
@@ -394,13 +394,6 @@ END_VAR
             RETURN;
         END_IF
 
-        //Repeat fine detection with target switch mode (see mInitSwitchMode)
-        IF (eCurrentDetectionMode = E_DetectionMode.eRising) AND (eFineSwitchMode = MC_Switch_Mode.mcFallingEdge) THEN
-            eFineSwitchMode := MC_Switch_Mode.mcRisingEdge;
-            eHomingState := E_HomeSequenceState.eInitDetetion;
-            RETURN;
-        END_IF
-
         eHomingState := E_HomeSequenceState.eFinishHoming;
 
 END_CASE
@@ -621,15 +614,7 @@ eCoarseSwitchMode := MC_Switch_Mode.mcOn;
 
 CASE eCurrentDetectionMode OF
     E_DetectionMode.eRising:
-        (*Reverse switch mode for the first execution of fine detect, if the switch is already engaged.
-        This fixes an issue where, when the routine start at the edge of the switch, the Step function
-        starts to oscillate back and forth at the edge because it misses the edge detection.*)
-        IF ((eSelectedHomingRoutine = eTO_LIMIT) AND stLimitSwitchSignal.Level)
-        OR ((eSelectedHomingRoutine = eTO_REF) AND stRefSwitchSignal.Level) THEN
-            eFineSwitchMode := MC_Switch_Mode.mcFallingEdge;
-        ELSE
-            eFineSwitchMode := MC_Switch_Mode.mcRisingEdge;
-        END_IF
+        eFineSwitchMode := MC_Switch_Mode.mcRisingEdge;
     E_DetectionMode.eFalling:
         eFineSwitchMode := MC_Switch_Mode.mcFallingEdge;
 END_CASE

--- a/POUs/Motion/Homing/FB_Homing.TcPOU
+++ b/POUs/Motion/Homing/FB_Homing.TcPOU
@@ -329,7 +329,6 @@ fbFinishHoming(
     Axis := Axis,
     Execute := eHomingState = E_HomeSequenceState.eFinishHoming,
     Velocity := fVelocityToCam,
-    Distance := fHomeFinishDistance,
     Parameter := stHomingParameter);
 
 fbAbortHoming.Options.DisableDriveAccess := stOptions.DisableDriveAccess;
@@ -392,6 +391,13 @@ END_VAR
             eHomingSpeed := eFINE;
             eHomingState := E_HomeSequenceState.eInitDetetion;
             RETURN;
+        END_IF
+
+        //Calculate distance for finish homing
+        IF stConfig.bAbsoluteMoveAtFinishHoming THEN
+            fbFinishHoming.Distance := fHomeFinishDistance - Axis.NcToPlc.ActPos;
+        ELSE
+            fbFinishHoming.Distance := fHomeFinishDistance;
         END_IF
 
         eHomingState := E_HomeSequenceState.eFinishHoming;

--- a/POUs/Motion/Homing/FB_Homing.TcPOU
+++ b/POUs/Motion/Homing/FB_Homing.TcPOU
@@ -14,7 +14,7 @@ VAR_INPUT
     eHomingRoutine: E_HomingRoutines := E_HomingRoutines.eNoHoming;
     fHomePosition: LREAL;
     fHomeFinishDistance: LREAL;
-    stConfig: ST_AxisConfig;
+    stConfig: ST_HomingConfig;
 END_VAR
 VAR_OUTPUT
     bDone: BOOL;
@@ -179,9 +179,9 @@ CASE eSelectedHomingRoutine OF
             Execute := (eHomingSpeed = eCOARSE) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
             Parameter := stHomingParameter,
             Direction := eCurrentDirection,
-            TimeLimit :=  stConfig.stHomingConfig.tTimeLimit,
-            DistanceLimit := stConfig.stHomingConfig.fDistanceLimit,
-            TorqueLimit := stConfig.stHomingConfig.fTorqueLimit, //The motor torque is limited to this value (percentage of configured channel peak torque), in relation to the weight counterbalance that is possibly parameterized in the drive, in order to avoid mechanical damage.
+            TimeLimit :=  stConfig.tTimeLimit,
+            DistanceLimit := stConfig.fDistanceLimit,
+            TorqueLimit := stConfig.fTorqueLimit, //The motor torque is limited to this value (percentage of configured channel peak torque), in relation to the weight counterbalance that is possibly parameterized in the drive, in order to avoid mechanical damage.
             LimitSwitchMode := eCoarseSwitchMode,
             LimitSwitchSignal := stLimitSwitchSignal,
             Velocity := fVelocityToCam,
@@ -197,9 +197,9 @@ CASE eSelectedHomingRoutine OF
             Execute := (eHomingSpeed = eFINE) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
             Parameter := stHomingParameter,
             Direction := eCurrentDirection,
-            TimeLimit :=  stConfig.stHomingConfig.tTimeLimit,
-            DistanceLimit := stConfig.stHomingConfig.fDistanceLimit,
-            TorqueLimit := stConfig.stHomingConfig.fTorqueLimit, //The motor torque is limited to this value (percentage of configured channel peak torque), in relation to the weight counterbalance that is possibly parameterized in the drive, in order to avoid mechanical damage.
+            TimeLimit :=  stConfig.tTimeLimit,
+            DistanceLimit := stConfig.fDistanceLimit,
+            TorqueLimit := stConfig.fTorqueLimit, //The motor torque is limited to this value (percentage of configured channel peak torque), in relation to the weight counterbalance that is possibly parameterized in the drive, in order to avoid mechanical damage.
             LimitSwitchMode := eFineSwitchMode,
             LimitSwitchSignal := stLimitSwitchSignal,
             Velocity := fVelocityFromCam,
@@ -218,9 +218,9 @@ CASE eSelectedHomingRoutine OF
             Execute := (eHomingSpeed = eCOARSE) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
             Parameter := stHomingParameter,
             Direction := eCurrentDirection,
-            TimeLimit :=  stConfig.stHomingConfig.tTimeLimit,
-            DistanceLimit := stConfig.stHomingConfig.fDistanceLimit,
-            TorqueLimit := stConfig.stHomingConfig.fTorqueLimit, //The motor torque is limited to this value (percentage of configured channel peak torque), in relation to the weight counterbalance that is possibly parameterized in the drive, in order to avoid mechanical damage.
+            TimeLimit :=  stConfig.tTimeLimit,
+            DistanceLimit := stConfig.fDistanceLimit,
+            TorqueLimit := stConfig.fTorqueLimit, //The motor torque is limited to this value (percentage of configured channel peak torque), in relation to the weight counterbalance that is possibly parameterized in the drive, in order to avoid mechanical damage.
             SwitchMode := eCoarseSwitchMode,
             ReferenceSignal := stRefSwitchSignal,
             PositiveLimitSwitch := NOT(bLimitFwd),
@@ -263,9 +263,9 @@ CASE eSelectedHomingRoutine OF
             Execute := (eHomingSpeed = eCOARSE) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
             Parameter := stHomingParameter,
             Direction := eCurrentReversedDirection,
-            TimeLimit :=  stConfig.stHomingConfig.tTimeLimit,
-            DistanceLimit := stConfig.stHomingConfig.fDistanceLimit,
-            TorqueLimit := stConfig.stHomingConfig.fTorqueLimit, //The motor torque is limited to this value (percentage of configured channel peak torque), in relation to the weight counterbalance that is possibly parameterized in the drive, in order to avoid mechanical damage.
+            TimeLimit :=  stConfig.tTimeLimit,
+            DistanceLimit := stConfig.fDistanceLimit,
+            TorqueLimit := stConfig.fTorqueLimit, //The motor torque is limited to this value (percentage of configured channel peak torque), in relation to the weight counterbalance that is possibly parameterized in the drive, in order to avoid mechanical damage.
             LimitSwitchMode := eCoarseSwitchMode,
             LimitSwitchSignal := stReversedLimitSwitchSignal,
             Velocity := fVelocityToCam,
@@ -281,9 +281,9 @@ CASE eSelectedHomingRoutine OF
             Execute := (eHomingSpeed = eFINE) AND (eHomingState = E_HomeSequenceState.eExecuteDetection),
             Parameter := stHomingParameter,
             Direction := eCurrentDirection,
-            TimeLimit :=  stConfig.stHomingConfig.tTimeLimit,
-            DistanceLimit := stConfig.stHomingConfig.fDistanceLimit,
-            TorqueLimit := stConfig.stHomingConfig.fTorqueLimit, //The motor torque is limited to this value (percentage of configured channel peak torque), in relation to the weight counterbalance that is possibly parameterized in the drive, in order to avoid mechanical damage.
+            TimeLimit :=  stConfig.tTimeLimit,
+            DistanceLimit := stConfig.fDistanceLimit,
+            TorqueLimit := stConfig.fTorqueLimit, //The motor torque is limited to this value (percentage of configured channel peak torque), in relation to the weight counterbalance that is possibly parameterized in the drive, in order to avoid mechanical damage.
             ReferenceSignal := stEncPulseSignal,
             Velocity := fVelocityFromCam,
             SetPosition := fHomePosition,
@@ -302,12 +302,12 @@ CASE eSelectedHomingRoutine OF
             Parameter := stHomingParameter,
             Direction := eCurrentDirection,
             Velocity := fVelocityFromCam,
-            DetectionVelocityLimit := stConfig.stHomingConfig.fDetectionVelocityLimit, //Velocity that must be fallen below for the time DetectionVelocityTime in order to detect driving against the fixed stop.
-            DetectionVelocityTime := stConfig.stHomingConfig.tDetectionVelocityTime, //Time for detecting the velocity undershoot when driving against the fixed stop.
-            TimeLimit :=  stConfig.stHomingConfig.tTimeLimit, //Exceeding this time leads to the search procedure being aborted.
-            DistanceLimit := stConfig.stHomingConfig.fDistanceLimit, //Exceeding this distance in relation to the start position leads to the search procedure being aborted.
-            TorqueLimit := stConfig.stHomingConfig.fTorqueLimit, //The motor torque is limited to this value (percentage of configured channel peak torque), in relation to the weight counterbalance that is possibly parameterized in the drive, in order to avoid mechanical damage.
-            LagLimit := stConfig.stHomingConfig.fLagLimit, //Position lag value which, if exceeded, leads to detection of driving against the fixed stop.
+            DetectionVelocityLimit := stConfig.fDetectionVelocityLimit, //Velocity that must be fallen below for the time DetectionVelocityTime in order to detect driving against the fixed stop.
+            DetectionVelocityTime := stConfig.tDetectionVelocityTime, //Time for detecting the velocity undershoot when driving against the fixed stop.
+            TimeLimit :=  stConfig.tTimeLimit, //Exceeding this time leads to the search procedure being aborted.
+            DistanceLimit := stConfig.fDistanceLimit, //Exceeding this distance in relation to the start position leads to the search procedure being aborted.
+            TorqueLimit := stConfig.fTorqueLimit, //The motor torque is limited to this value (percentage of configured channel peak torque), in relation to the weight counterbalance that is possibly parameterized in the drive, in order to avoid mechanical damage.
+            LagLimit := stConfig.fLagLimit, //Position lag value which, if exceeded, leads to detection of driving against the fixed stop.
             SetPosition := fHomePosition,
             Options := stOptions3,
             Done => bFineDone,
@@ -710,7 +710,7 @@ END_VAR
 
     E_HomeSequenceState.eWaitForExecute:
         IF rtrigExecute.Q THEN
-            eCurrentDetectionMode := stConfig.stHomingConfig.eDetectionMode;
+            eCurrentDetectionMode := stConfig.eDetectionMode;
 
             mInitRoutineWithDirection();
             mInitEnable();

--- a/VISUs/MainVisu.TcVIS
+++ b/VISUs/MainVisu.TcVIS
@@ -1981,7 +1981,7 @@ GVL.astAxes[MAIN.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                     </o>
                     <o>
                       <v n="Id">1649127785L</v>
-                      <v n="Value">805</v>
+                      <v n="Value">868</v>
                     </o>
                     <o>
                       <v n="Id">357335551L</v>
@@ -2036,7 +2036,7 @@ GVL.astAxes[MAIN.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                     </o>
                     <o>
                       <v n="Id">550940142L</v>
-                      <v n="Value">902</v>
+                      <v n="Value">965</v>
                     </o>
                     <o>
                       <v n="Id">1473355128L</v>
@@ -2169,7 +2169,7 @@ GVL.astAxes[MAIN.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                         </o>
                         <o>
                           <v n="Id">2422045748L</v>
-                          <v n="Value">335</v>
+                          <v n="Value">405</v>
                         </o>
                         <o>
                           <v n="Id">2134141914L</v>
@@ -2196,7 +2196,7 @@ GVL.astAxes[MAIN.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                         </o>
                         <o>
                           <v n="Id">550940142L</v>
-                          <v n="Value">169</v>
+                          <v n="Value">204</v>
                         </o>
                         <o>
                           <v n="Id">1473355128L</v>
@@ -6768,6 +6768,165 @@ GVL.astAxes[Main.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                     <v n="VisualElementId">314</v>
                     <l n="UserManagementAccessRights" t="ArrayList" />
                   </o>
+                  <o>
+                    <a n="ConfiguredComplexInputs" et="ComplexInput" />
+                    <l n="Elements" t="ArrayList" />
+                    <n n="VisualElementDescription" />
+                    <o n="VisualElemMemberList" t="VisualElemMemberList">
+                      <l n="VisualElemMemberList" t="VisualElemMemberCollection" cet="VisualElemMember">
+                        <o>
+                          <v n="Id">571893170L</v>
+                          <v n="Value">""</v>
+                        </o>
+                        <o>
+                          <v n="Id">494569607L</v>
+                          <o n="Value" t="NamedStyleColor">
+                            <v n="Color">-2830136</v>
+                            <v n="CanonicalName">"Element-Frame-Color"</v>
+                          </o>
+                        </o>
+                        <o>
+                          <v n="Id">2812299069L</v>
+                          <l n="Value" t="ArrayList" cet="NamedStyleColor">
+                            <o>
+                              <v n="Color">-1381912</v>
+                              <v n="CanonicalName">"Element-Background-Color"</v>
+                            </o>
+                          </l>
+                        </o>
+                        <o>
+                          <v n="Id">135947015L</v>
+                          <l n="Value" t="ArrayList" cet="NamedStyleColor">
+                            <o>
+                              <v n="Color">-65536</v>
+                              <v n="CanonicalName">"Element-Alarm-Frame-Color"</v>
+                            </o>
+                          </l>
+                        </o>
+                        <o>
+                          <v n="Id">493260384L</v>
+                          <l n="Value" t="ArrayList" cet="NamedStyleColor">
+                            <o>
+                              <v n="Color">-12337</v>
+                              <v n="CanonicalName">"Element-Alarm-Fill-Color"</v>
+                            </o>
+                          </l>
+                        </o>
+                        <o>
+                          <v n="Id">2340015797L</v>
+                          <v n="Value">"HCENTER"</v>
+                        </o>
+                        <o>
+                          <v n="Id">2565699834L</v>
+                          <v n="Value">"VCENTER"</v>
+                        </o>
+                        <o>
+                          <v n="Id">4134387352L</v>
+                          <v n="Value">"NONE"</v>
+                        </o>
+                        <o>
+                          <v n="Id">1603690730L</v>
+                          <v n="Value">"Arial"</v>
+                        </o>
+                        <o>
+                          <v n="Id">4253639993L</v>
+                          <v n="Value" t="Int16">12</v>
+                        </o>
+                        <o>
+                          <v n="Id">2729990903L</v>
+                          <v n="Value">0U</v>
+                        </o>
+                        <o>
+                          <v n="Id">1213979116L</v>
+                          <v n="Value">0U</v>
+                        </o>
+                        <o>
+                          <v n="Id">3488306084L</v>
+                          <v n="Value">4278190080U</v>
+                        </o>
+                        <o>
+                          <v n="Id">1999528970L</v>
+                          <v n="Value">"&lt;toggle/tap variable&gt;"</v>
+                        </o>
+                        <o>
+                          <v n="Id">1649127785L</v>
+                          <v n="Value" t="Int16">328</v>
+                        </o>
+                        <o>
+                          <v n="Id">357335551L</v>
+                          <v n="Value" t="Int16">489</v>
+                        </o>
+                        <o>
+                          <v n="Id">2422045748L</v>
+                          <v n="Value">74</v>
+                        </o>
+                        <o>
+                          <v n="Id">2134141914L</v>
+                          <v n="Value">30</v>
+                        </o>
+                        <o>
+                          <v n="Id">3729828405L</v>
+                          <l n="Value" t="ArrayList" cet="NamedStyleFont">
+                            <o>
+                              <v n="FontStyle">0</v>
+                              <v n="AdditionalFontStyle" t="UInt16">0</v>
+                              <v n="ExplicitColor">-16777216</v>
+                              <v n="CanonicalName">"Font-Standard"</v>
+                              <v n="FontName">"Arial"</v>
+                              <v n="FontSize">12</v>
+                              <v n="ScriptIdentification">0</v>
+                              <v n="DoubleFontSize" t="Double">0</v>
+                              <o n="NamedColor" t="NamedStyleColor">
+                                <v n="Color">-16777216</v>
+                                <v n="CanonicalName">"Font-Default-Color"</v>
+                              </o>
+                            </o>
+                          </l>
+                        </o>
+                        <o>
+                          <v n="Id">1337389588L</v>
+                          <v n="Value">"RAISED"</v>
+                        </o>
+                        <o>
+                          <v n="Id">2678395525L</v>
+                          <v n="Value">1U</v>
+                        </o>
+                        <o>
+                          <v n="Id">390574330L</v>
+                          <v n="Value">"%s"</v>
+                        </o>
+                        <o>
+                          <v n="Id">2477733581L</v>
+                          <v n="Value">"SEL(GVL.astAxes[Main.hmiAxisSelection].stConfig.stHomingConfig.bAbsoluteMoveAtFinishHoming, 'Relative', 'Absolute');"</v>
+                        </o>
+                        <o>
+                          <v n="Id">2597686782L</v>
+                          <v n="Value">false</v>
+                        </o>
+                        <o>
+                          <v n="Id">3719097617L</v>
+                          <v n="Value">0</v>
+                        </o>
+                        <o>
+                          <v n="Id">823443203L</v>
+                          <v n="Value">"821"</v>
+                        </o>
+                      </l>
+                    </o>
+                    <v n="VisualElementName">"Textfield"</v>
+                    <v n="VisualElementTypeName">"VisuFbElemTextfield"</v>
+                    <v n="VisualElementIsRectangle">true</v>
+                    <v n="VisualElementIdentifier">"GenElemInst_800"</v>
+                    <n n="VisualElementOfflinePaintCommands" />
+                    <n n="VisualElementFrameInformation" />
+                    <d n="VisualElementInputActions" t="Hashtable" />
+                    <v n="VisualElementIdentification">{759bd9b6-4245-4f7a-aeab-5b72b57b4a27}</v>
+                    <v n="VisualElementOwningObjectGuid">{63eeb817-1a76-06e3-215d-714040055109}</v>
+                    <a n="LMGuids" et="Guid" />
+                    <d n="SubElements" t="Hashtable" />
+                    <v n="VisualElementId">792</v>
+                    <l n="UserManagementAccessRights" t="ArrayList" />
+                  </o>
                 </l>
                 <n n="VisualElementDescription" />
                 <o n="VisualElemMemberList" t="VisualElemMemberList">
@@ -6852,7 +7011,7 @@ GVL.astAxes[Main.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                     </o>
                     <o>
                       <v n="Id">2422045748L</v>
-                      <v n="Value">340</v>
+                      <v n="Value">407</v>
                     </o>
                     <o>
                       <v n="Id">2134141914L</v>
@@ -18302,7 +18461,7 @@ GVL.astAxes[Main.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                     </o>
                     <o>
                       <v n="Id">1649127785L</v>
-                      <v n="Value" t="Int16">792</v>
+                      <v n="Value" t="Int16">855</v>
                     </o>
                     <o>
                       <v n="Id">357335551L</v>
@@ -18479,7 +18638,7 @@ GVL.astAxes[Main.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                     </o>
                     <o>
                       <v n="Id">1649127785L</v>
-                      <v n="Value" t="Int16">792</v>
+                      <v n="Value" t="Int16">855</v>
                     </o>
                     <o>
                       <v n="Id">357335551L</v>
@@ -22865,7 +23024,7 @@ GVL.astAxes[MAIN.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                     </o>
                     <o>
                       <v n="Id">1649127785L</v>
-                      <v n="Value">805</v>
+                      <v n="Value">868</v>
                     </o>
                     <o>
                       <v n="Id">357335551L</v>
@@ -22920,7 +23079,7 @@ GVL.astAxes[MAIN.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                     </o>
                     <o>
                       <v n="Id">550940142L</v>
-                      <v n="Value">904</v>
+                      <v n="Value">967</v>
                     </o>
                     <o>
                       <v n="Id">1473355128L</v>
@@ -23050,7 +23209,7 @@ GVL.astAxes[MAIN.hmiAxisSelection].stControl.bExecute:=TRUE;"</v>
                     </o>
                     <o>
                       <v n="Id">1649127785L</v>
-                      <v n="Value">817</v>
+                      <v n="Value">880</v>
                     </o>
                     <o>
                       <v n="Id">357335551L</v>
@@ -36566,7 +36725,7 @@ GVL.astAxes[Main.hmiAxisSelection].stControl.bExecute := TRUE;"</v>
             </o>
             <v n="DialogDut">{922df0df-545b-4a6e-ab04-d027f2e1dfa1}</v>
           </o>
-          <v n="LastUsedIdForIdentifier">798</v>
+          <v n="LastUsedIdForIdentifier">800</v>
           <o n="TextDocument" t="TextDocument">
             <a n="TextLines" cet="TextLine">
               <o>

--- a/VISUs/languageSupport.TcTLO
+++ b/VISUs/languageSupport.TcTLO
@@ -351,7 +351,7 @@
             </o>
             <o>
               <v n="TextID">"fHomeFinishDistance"</v>
-              <v n="TextDefault">"Relative Move after Homing"</v>
+              <v n="TextDefault">"Move after Homing"</v>
               <l n="LanguageTexts" t="ArrayList" cet="String">
                 <v></v>
               </l>


### PR DESCRIPTION
The following improvements/fixes were found during some further texting of the reworked homing:
1. Homing should provide a way to configure if the switches/home sensor is normally closed or open.
2. There are some inconsistencies, when Homing To Ref is used. This should be rigorously tested to compare every scenario for Homing To Ref to the old homing.

