### PR TITLE
Mbp 405 reset error bit for custom errors

### DIFF
--- a/DUTs/Axis_Structures/ST_AxisError.TcDUT
+++ b/DUTs/Axis_Structures/ST_AxisError.TcDUT
@@ -15,9 +15,13 @@ STRUCT
     nStopErrorID: UDINT;//Error ID for MC_Stop function block
     nGearInMultiMasterErrorID: UDINT; //Error ID for MC_GearInMultiMaster function block
     nGearOutErrorID: UDINT; //Error ID for MC_GearOut function block
-    nWriteParameterErrorId: UDINT; //Error ID for writing parameters function block
-    nReadParameterErrorId: UDINT; //Error ID for MC_ReadParameter function block
+    nWriteParameterErrorID: UDINT; //Error ID for writing parameters function block
+    nReadParameterErrorID: UDINT; //Error ID for MC_ReadParameter function block
     nBacklashErrorID: UDINT; //Error ID for MC_BacklashCompensation function block
+    nTempDisableErrorID: UDINT; //Error ID for mControl_TemperatureDisable method
+    nCommandHandlerErrorID: UDINT; //Error ID for mControl_CommandHandler method
+    nAirpadErrorID: UDINT; //Error ID for mControl_Airpad method
+    nExternalBrakeErrorID: UDINT; //Error ID for mControl_ExternalBrake method
 //Error from the NC
     nNCErrorID: UDINT; //Error ID from the NC Axis_Ref Axis Status
 END_STRUCT

--- a/DUTs/E_CustomErrorIds.TcTLEO
+++ b/DUTs/E_CustomErrorIds.TcTLEO
@@ -10,10 +10,9 @@ TYPE E_CustomErrorIds :
     eNoCustomError := 0,
     eTemperatureSensorError := 16#10201,
     eAirPadPressureError := 16#10202,
-    eAirPadTimeoutError := 16#10203,
-    eExternalBrakeError := 16#10204,
-    eExternalBrakeTimeoutError := 16#10205,
-    eCommandHandlerTimeoutError := 16#10206
+    eExternalBrakeError := 16#10203,
+    eExternalBrakeTimeoutError := 16#10204,
+    eCommandHandlerTimeoutError := 16#10205
 ) UDINT := eNoCustomError;
 END_TYPE
 ]]></Declaration>
@@ -37,23 +36,18 @@ END_TYPE
               <l n="LanguageTexts" t="ArrayList" />
             </o>
             <o>
-              <v n="TextID">"eAirPadTimeoutError"</v>
+              <v n="TextID">"eExternalBrakeError"</v>
               <v n="TextDefault">"16#10203"</v>
               <l n="LanguageTexts" t="ArrayList" />
             </o>
             <o>
-              <v n="TextID">"eExternalBrakeError"</v>
+              <v n="TextID">"eExternalBrakeTimeoutError"</v>
               <v n="TextDefault">"16#10204"</v>
               <l n="LanguageTexts" t="ArrayList" />
             </o>
             <o>
-              <v n="TextID">"eExternalBrakeTimeoutError"</v>
-              <v n="TextDefault">"16#10205"</v>
-              <l n="LanguageTexts" t="ArrayList" />
-            </o>
-            <o>
               <v n="TextID">"eCommandHandlerTimeoutError"</v>
-              <v n="TextDefault">"16#10206"</v>
+              <v n="TextDefault">"16#10205"</v>
               <l n="LanguageTexts" t="ArrayList" />
             </o>
             <o>

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -533,8 +533,10 @@ mControl_CommandHandler.CommandAborted := bCommandAborted;
 mControl_CommandHandler.Done := bInternalExecute;
 mControl_CommandHandler.Busy := (eState <> E_CommandHandlerState.eIdle);
 mControl_CommandHandler.Error := _stAxis.stStatus.bCommandHandlerTimeoutError;
+
 IF _stAxis.stStatus.bCommandHandlerTimeoutError THEN
     mControl_CommandHandler.ErrorID := TO_UDINT(E_CustomErrorIds.eCommandHandlerTimeoutError);
+    _stAxis.stError.nCommandHandlerErrorID := mControl_CommandHandler.ErrorID;
 END_IF
 ]]></ST>
       </Implementation>

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -124,6 +124,8 @@ END_VAR
 VAR CONSTANT
     nRATIO_DENOMINATOR_DEFAULT: UINT := 1;
     nNO_GEARING: UINT := 0;
+    nFIRST_ARRAY_INDEX_MOVE_COMMANDS: UINT := 5; //USed for the FOR loops for the Busy, Done, Command Aborted Status
+    nLAST_ARRAY_INDEX_MOVE_COMMANDS: UINT := 15; //USed for the FOR loops for Done
     nMCSTATUS_ARRAY_SIZE: UINT := 19;
     nMULTI_MASTER_MAX_AXES: UINT := 4;
 END_VAR
@@ -1795,7 +1797,7 @@ VAR
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[FOR i := 5 TO nMCSTATUS_ARRAY_SIZE DO
+        <ST><![CDATA[FOR i := nFIRST_ARRAY_INDEX_MOVE_COMMANDS TO nMCSTATUS_ARRAY_SIZE DO
     tmpBusy := astMcStatus[i]^.Busy OR tmpBusy;
 END_FOR
 mStatus_Busy := tmpBusy;
@@ -1810,7 +1812,7 @@ VAR
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[FOR i := 5 TO nMCSTATUS_ARRAY_SIZE DO
+        <ST><![CDATA[FOR i := nFIRST_ARRAY_INDEX_MOVE_COMMANDS TO nMCSTATUS_ARRAY_SIZE DO
     tmpCmdAborted := astMcStatus[i]^.CommandAborted OR tmpCmdAborted;
 END_FOR
 
@@ -1829,14 +1831,8 @@ VAR
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[FOR i := 5 TO nMCSTATUS_ARRAY_SIZE DO
-    //Ignore Done bits of this methods
-    IF i <> 16 //mControl_TemperatureDisable
-    OR i <> 17 //mControl_CommandHandler
-    OR i <> 18 //mControl_Airpad
-    OR i <> 19 THEN //mControl_ExternalBrake
-        tmpDone := astMcStatus[i]^.Done OR tmpDone;
-    END_IF
+        <ST><![CDATA[FOR i := nFIRST_ARRAY_INDEX_MOVE_COMMANDS TO nLAST_ARRAY_INDEX_MOVE_COMMANDS DO
+    tmpDone := astMcStatus[i]^.Done OR tmpDone;
 END_FOR
 //fbDoneRTrig(CLK:= mStatus_Done());
 fbDoneRTrig(CLK := tmpDone);
@@ -1886,14 +1882,14 @@ ELSIF _stAxis.Axis.Status.Error THEN
 //FBs and custom methods errors
 ELSIF fbErrorRTrig.Q THEN
     //For each mcStatus
-    IF astMcStatus[16]^.Error
-    OR astMcStatus[17]^.Error
-    OR astMcStatus[18]^.Error
-    OR astMcStatus[19]^.Error THEN
-         _stAxis.stStatus.bError := TRUE;
-    ELSE
-        _stAxis.stStatus.bError := _stAxis.Axis.Status.ErrorStop;
-    END_IF
+    FOR i := nLAST_ARRAY_INDEX_MOVE_COMMANDS TO nMCSTATUS_ARRAY_SIZE DO
+         IF astMcStatus[i]^.Error THEN
+            _stAxis.stStatus.bError := TRUE;
+           ELSE
+                _stAxis.stStatus.bError := _stAxis.Axis.Status.ErrorStop;
+        END_IF
+    END_FOR
+
     FOR i := 1 TO nMCSTATUS_ARRAY_SIZE DO
         //If there's an error present propagate
         IF astMcStatus[i]^.ErrorID <> 0 THEN

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -1090,6 +1090,10 @@ _stAxis.stStatus.bTempSensorError := bTempSensorError;
 mControl_TemperatureDisable.Active := bEnableTemperatureDisable;
 mControl_TemperatureDisable.Error := bTempSensorError;
 mControl_TemperatureDisable.ErrorID := nErrorID;
+
+IF bTempSensorError THEN
+    _stAxis.stError.nTempDisableErrorID := nErrorID;
+END_IF
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -1888,13 +1888,23 @@ ELSE
     stAxis.stStatus.nSoEDiagID := 0;
 END_IF
 
+//NC Errors
 IF _stAxis.Axis.Status.ErrorStop THEN
     _stAxis.stStatus.bError := _stAxis.Axis.Status.ErrorStop;
     _stAxis.stStatus.nErrorID := _stAxis.Axis.Status.ErrorID;//NC Error ID
 ELSIF _stAxis.Axis.Status.Error THEN
     _stAxis.stStatus.nErrorID := _stAxis.stError.nNCErrorID;
+//FBs and custom methods errors
 ELSIF fbErrorRTrig.Q THEN
     //For each mcStatus
+    IF astMcStatus[16]^.Error
+    OR astMcStatus[17]^.Error
+    OR astMcStatus[18]^.Error
+    OR astMcStatus[19]^.Error THEN
+         _stAxis.stStatus.bError := TRUE;
+    ELSE
+        _stAxis.stStatus.bError := _stAxis.Axis.Status.ErrorStop;
+    END_IF
     FOR i := 1 TO nMCSTATUS_ARRAY_SIZE DO
         //If there's an error present propagate
         IF astMcStatus[i]^.ErrorID <> 0 THEN

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1">
   <POU Name="FB_Axis" Id="{beb60ab5-3bf2-0ae6-2037-f6d7e95a54b2}" SpecialFunc="None">
     <Declaration><![CDATA[//Function block to run a virtual drive with Nc
@@ -212,7 +212,6 @@ VAR_INST
     bPressureOnRequest: BOOL := FALSE;
     RTRIG_ManualControl: R_TRIG;
 
-    bAirpadError: BOOL;
     nAirpadErrorId: UDINT := 0;
 END_VAR
 ]]></Declaration>
@@ -254,11 +253,9 @@ CASE eAirpad OF
     E_Airpad.eDepressurize:
         //No movement requested -> Airpad off
         _stAxis.stControl.bPressurizeAirpad := FALSE;
-        bAirpadError := FALSE;
         IF bPressureOnRequest
             AND NOT _stAxis.stStatus.bError
             AND NOT _stAxis.stStatus.bAirpadPressureError THEN
-            bAirpadError := FALSE;
             _stAxis.stStatus.bAirpadPressureError := FALSE;
             nAirpadErrorId := 0;
             eAirpad := E_Airpad.ePressurize;
@@ -271,12 +268,11 @@ CASE eAirpad OF
 
         IF _stAxis.stStatus.bError
             OR NOT bPressureOnRequest
-            OR bAirpadError THEN
+            OR _stAxis.stStatus.bAirpadPressureError THEN
             eAirpad := E_Airpad.eDepressurize;
         ELSIF TON_PressurizeAirpad.Q THEN
             IF _stAxis.stConfig.stAirpadBrake.bAirpadFeedbackConnected
                 AND NOT _stAxis.stInputs.bAirpadPressurized THEN
-                bAirpadError := TRUE;
                 _stAxis.stStatus.bAirpadPressureError := TRUE;
                 nAirpadErrorId := E_CustomErrorIds.eAirPadPressureError;
                 eAirpad := E_Airpad.eDepressurize;
@@ -292,11 +288,10 @@ CASE eAirpad OF
 
         IF _stAxis.stStatus.bError
             OR TON_Depressurize.Q
-            OR bAirpadError THEN
+            OR _stAxis.stStatus.bAirpadPressureError THEN
             eAirpad := E_Airpad.eDepressurize;
         ELSIF (_stAxis.stConfig.stAirpadBrake.bAirpadFeedbackConnected
             AND NOT _stAxis.stInputs.bAirpadPressurized) THEN
-            bAirpadError := TRUE;
             _stAxis.stStatus.bAirpadPressureError := TRUE;
             nAirpadErrorId := E_CustomErrorIds.eAirPadPressureError;
             eAirpad := E_Airpad.eDepressurize;
@@ -310,10 +305,10 @@ bReady := eAirpad = E_Airpad.eReadyToMove
     OR NOT _stAxis.stConfig.stAirpadBrake.bAirpadFeedbackConnected);
 
 //ST_McStatus mapping
-mControl_Airpad.Error := bAirpadError;
+mControl_Airpad.Error := _stAxis.stStatus.bAirpadPressureError;
 mControl_Airpad.ErrorID := nAirpadErrorId;
 
-IF bAirpadError THEN
+IF _stAxis.stStatus.bAirpadPressureError THEN
     _stAxis.stError.nAirpadErrorID := nAirpadErrorId;
 END_IF
 

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -957,24 +957,30 @@ IF fbReset.Done
     _stAxis.stStatus.bExternalBrakeTimeoutError := FALSE;
     _stAxis.stStatus.bExternalBrakeFailure := FALSE;
     FOR i := 1 TO nMCSTATUS_ARRAY_SIZE DO
-        //Reset ST_Status error ID
-        _stAxis.stStatus.nErrorID := 0;
-        //Reset St_AxisError error IDs
-        _stAxis.stError.nPowerErrorID := 0;
-        _stAxis.stError.nMoveAbsoluteErrorID := 0;
-        _stAxis.stError.nMoveRelativeErrorID := 0;
-        _stAxis.stError.nMoveVelocityErrorID := 0;
-        _stAxis.stError.nMoveModuloErrorID := 0;
-        _stAxis.stError.nHomeErrorID := 0;
-        _stAxis.stError.nHaltErrorID := 0;
-        _stAxis.stError.nResetErrorID := 0;
-        _stAxis.stError.nStopErrorID := 0;
-        _stAxis.stError.nGearInMultiMasterErrorID := 0;
-        _stAxis.stError.nGearOutErrorID := 0;
-        _stAxis.stError.nWriteParameterErrorId := 0;
-        _stAxis.stError.nReadParameterErrorId := 0;
-        _stAxis.stError.nNCErrorID := 0;
+        astMcStatus[i]^.Error := FALSE;
     END_FOR
+        //Reset ST_Status error ID
+    _stAxis.stStatus.nErrorID := 0;
+        //Reset St_AxisError error IDs
+    _stAxis.stError.nPowerErrorID := 0;
+    _stAxis.stError.nMoveAbsoluteErrorID := 0;
+    _stAxis.stError.nMoveRelativeErrorID := 0;
+    _stAxis.stError.nMoveVelocityErrorID := 0;
+    _stAxis.stError.nMoveModuloErrorID := 0;
+    _stAxis.stError.nHomeErrorID := 0;
+    _stAxis.stError.nHaltErrorID := 0;
+    _stAxis.stError.nResetErrorID := 0;
+    _stAxis.stError.nStopErrorID := 0;
+    _stAxis.stError.nGearInMultiMasterErrorID := 0;
+    _stAxis.stError.nGearOutErrorID := 0;
+    _stAxis.stError.nWriteParameterErrorID := 0;
+    _stAxis.stError.nReadParameterErrorID := 0;
+    _stAxis.stError.nTempDisableErrorID := 0;
+    _stAxis.stError.nCommandHandlerErrorID := 0;
+    _stAxis.stError.nAirpadErrorID := 0;
+    _stAxis.stError.nExternalBrakeErrorID :=0;
+    _stAxis.stError.nNCErrorID := 0;
+
 END_IF
 
 mControl_Reset.Busy := fbReset.Busy OR fbSoEReset.Busy;

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -239,6 +239,7 @@ RTRIG_PressureRequest(CLK := bPressureOnRequest);
 
 TON_PressurizeAirpad(
     IN := bPressureOnRequest
+        AND NOT _stAxis.stStatus.bError
         AND ((_stAxis.stConfig.stAirpadBrake.bAirpadFeedbackConnected
             AND _stAxis.stInputs.bAirpadPressurized)
         OR NOT _stAxis.stConfig.stAirpadBrake.bAirpadFeedbackConnected),
@@ -257,13 +258,11 @@ CASE eAirpad OF
     E_Airpad.eDepressurize:
         //No movement requested -> Airpad off
         _stAxis.stControl.bPressurizeAirpad := FALSE;
+        bAirpadError := FALSE;
         IF bPressureOnRequest
             AND NOT _stAxis.stStatus.bError
             AND NOT _stAxis.stStatus.bAirpadPressureError
             AND NOT _stAxis.stStatus.bAirpadTimeoutError THEN
-            bAirpadError := FALSE;
-            _stAxis.stStatus.bAirpadTimeoutError := FALSE;
-            _stAxis.stStatus.bAirpadPressureError := FALSE;
             nAirpadErrorId := 0;
             eAirpad := E_Airpad.ePressurize;
         END_IF
@@ -273,7 +272,9 @@ CASE eAirpad OF
         //Movement requested -> Pressurize airpad
         _stAxis.stControl.bPressurizeAirpad := TRUE;
 
-        IF _stAxis.stStatus.bError OR NOT bPressureOnRequest THEN
+        IF _stAxis.stStatus.bError
+            OR NOT bPressureOnRequest
+            OR bAirpadError THEN
             eAirpad := E_Airpad.eDepressurize;
         ELSIF TON_PressurizeTimeout.Q THEN
             IF _stAxis.stConfig.stAirpadBrake.bAirpadFeedbackConnected
@@ -298,7 +299,8 @@ CASE eAirpad OF
         _stAxis.stControl.bPressurizeAirpad := TRUE;
 
         IF _stAxis.stStatus.bError
-            OR TON_Depressurize.Q THEN
+            OR TON_Depressurize.Q
+            OR  bAirpadError THEN
             eAirpad := E_Airpad.eDepressurize;
         ELSIF (_stAxis.stConfig.stAirpadBrake.bAirpadFeedbackConnected
             AND NOT _stAxis.stInputs.bAirpadPressurized) THEN
@@ -319,6 +321,10 @@ bReady :=
 //ST_McStatus mapping
 mControl_Airpad.Error := bAirpadError;
 mControl_Airpad.ErrorID := nAirpadErrorId;
+
+IF     bAirpadError THEN
+    _stAxis.stError.nAirpadErrorID := nAirpadErrorId;
+END_IF
 
 
 ]]></ST>

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -238,10 +238,7 @@ RTRIG_PressureRequest(CLK := bPressureOnRequest);
 
 TON_PressurizeAirpad(
     IN := bPressureOnRequest
-        AND NOT _stAxis.stStatus.bError
-        AND ((_stAxis.stConfig.stAirpadBrake.bAirpadFeedbackConnected
-            AND _stAxis.stInputs.bAirpadPressurized)
-        OR NOT _stAxis.stConfig.stAirpadBrake.bAirpadFeedbackConnected),
+        AND NOT _stAxis.stStatus.bError,
     PT := _stAxis.stConfig.stAirpadBrake.tAirpadOnDelayTime);
 
 TON_Depressurize(

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -73,7 +73,7 @@ VAR
     stMcStatusTempDisable: ST_McStatus;
     stMcStatusCommandHandler: ST_McStatus;
     stMcStatusAirpad: ST_McStatus;
-    stMcStatusBrake: ST_McStatus;
+    stMcStatusExternalBrake: ST_McStatus;
 
     //Variables for holding limits during homing
     bWaitForStopAfterLimitHit: BOOL := FALSE;
@@ -185,7 +185,7 @@ astMcStatus[15] := ADR(stMcStatusBacklash);
 astMcStatus[16] := ADR(stMcStatusTempDisable);
 astMcStatus[17] := ADR(stMcStatusCommandHandler);
 astMcStatus[18] := ADR(stMcStatusAirpad);
-astMcStatus[19] := ADR(stMcStatusBrake);
+astMcStatus[19] := ADR(stMcStatusExternalBrake);
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -1841,7 +1841,11 @@ END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[FOR i := 5 TO nMCSTATUS_ARRAY_SIZE DO
-    IF i <> 16 THEN
+    //Ignore Done bits of this methods
+    IF i <> 16 //mControl_TemperatureDisable
+    OR i <> 17 //mControl_CommandHandler
+    OR i <> 18 //mControl_Airpad
+    OR i <> 19 THEN //mControl_ExternalBrake
         tmpDone := astMcStatus[i]^.Done OR tmpDone;
     END_IF
 END_FOR

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -1873,27 +1873,32 @@ ELSE
     stAxis.stStatus.nSoEDiagID := 0;
 END_IF
 
-//NC Errors
-IF _stAxis.Axis.Status.ErrorStop THEN
-    _stAxis.stStatus.bError := _stAxis.Axis.Status.ErrorStop;
-    _stAxis.stStatus.nErrorID := _stAxis.Axis.Status.ErrorID;//NC Error ID
-ELSIF _stAxis.Axis.Status.Error THEN
-    _stAxis.stStatus.nErrorID := _stAxis.stError.nNCErrorID;
-//FBs and custom methods errors
-ELSIF fbErrorRTrig.Q THEN
-    //For each mcStatus
-    FOR i := nLAST_ARRAY_INDEX_MOVE_COMMANDS TO nMCSTATUS_ARRAY_SIZE DO
-         IF astMcStatus[i]^.Error THEN
-            _stAxis.stStatus.bError := TRUE;
-           ELSE
-                _stAxis.stStatus.bError := _stAxis.Axis.Status.ErrorStop;
-        END_IF
-    END_FOR
+//Evaluate overall axis error, default to the NC's ErrorStop status
+_stAxis.stStatus.bError := _stAxis.Axis.Status.ErrorStop;
 
+//Override with TRUE if any custom method has an error
+FOR i := (nLAST_ARRAY_INDEX_MOVE_COMMANDS + 1) TO nMCSTATUS_ARRAY_SIZE DO
+    IF astMcStatus[i]^.Error THEN
+        _stAxis.stStatus.bError := TRUE;
+    END_IF
+END_FOR
+
+//Only allow nErrorID to be set if it is currently 0 (healthy). 
+//This creates a snapshot of the root cause.
+IF _stAxis.stStatus.nErrorID = 0 THEN
+    //Set the NC Error ID as a baseline fallback
+    IF _stAxis.Axis.Status.ErrorStop THEN
+        _stAxis.stStatus.nErrorID := _stAxis.Axis.Status.ErrorID;
+    ELSIF _stAxis.Axis.Status.Error THEN
+        _stAxis.stStatus.nErrorID := _stAxis.stError.nNCErrorID;
+    END_IF
+
+    //Overwrite with Function Block / Custom Errors if present.
+    //Because this executes after the NC check, the FB error gets priority.
     FOR i := 1 TO nMCSTATUS_ARRAY_SIZE DO
-        //If there's an error present propagate
         IF astMcStatus[i]^.ErrorID <> 0 THEN
             _stAxis.stStatus.nErrorID := astMcStatus[i]^.ErrorID;
+            EXIT;
         END_IF
     END_FOR
 END_IF

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -123,8 +123,8 @@ END_VAR
 VAR CONSTANT
     nRATIO_DENOMINATOR_DEFAULT: UINT := 1;
     nNO_GEARING: UINT := 0;
-    nFIRST_ARRAY_INDEX_MOVE_COMMANDS: UINT := 5; //USed for the FOR loops for the Busy, Done, Command Aborted Status
-    nLAST_ARRAY_INDEX_MOVE_COMMANDS: UINT := 15; //USed for the FOR loops for Done
+    nFIRST_ARRAY_INDEX_MOVE_COMMANDS: UINT := 5; //Used for the FOR loops for the Busy, Done, Command Aborted Status
+    nLAST_ARRAY_INDEX_MOVE_COMMANDS: UINT := 15; //Used for the FOR loops for Done
     nMCSTATUS_ARRAY_SIZE: UINT := 19;
     nMULTI_MASTER_MAX_AXES: UINT := 4;
 END_VAR
@@ -951,25 +951,8 @@ IF fbReset.Done
     END_FOR
     //Reset ST_Status error ID
     _stAxis.stStatus.nErrorID := 0;
-    //Reset St_AxisError error IDs
-    _stAxis.stError.nPowerErrorID := 0;
-    _stAxis.stError.nMoveAbsoluteErrorID := 0;
-    _stAxis.stError.nMoveRelativeErrorID := 0;
-    _stAxis.stError.nMoveVelocityErrorID := 0;
-    _stAxis.stError.nMoveModuloErrorID := 0;
-    _stAxis.stError.nHomeErrorID := 0;
-    _stAxis.stError.nHaltErrorID := 0;
-    _stAxis.stError.nResetErrorID := 0;
-    _stAxis.stError.nStopErrorID := 0;
-    _stAxis.stError.nGearInMultiMasterErrorID := 0;
-    _stAxis.stError.nGearOutErrorID := 0;
-    _stAxis.stError.nWriteParameterErrorID := 0;
-    _stAxis.stError.nReadParameterErrorID := 0;
-    _stAxis.stError.nTempDisableErrorID := 0;
-    _stAxis.stError.nCommandHandlerErrorID := 0;
-    _stAxis.stError.nAirpadErrorID := 0;
-    _stAxis.stError.nExternalBrakeErrorID :=0;
-    _stAxis.stError.nNCErrorID := 0;
+    //Reset St_AxisError error IDs (MEMSET ensures future additions are automatically handled)
+    MEMSET(ADR(_stAxis.stError), 0, SIZEOF(_stAxis.stError));
 
 END_IF
 

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -291,7 +291,7 @@ CASE eAirpad OF
 
         IF _stAxis.stStatus.bError
             OR TON_Depressurize.Q
-            OR  bAirpadError THEN
+            OR bAirpadError THEN
             eAirpad := E_Airpad.eDepressurize;
         ELSIF (_stAxis.stConfig.stAirpadBrake.bAirpadFeedbackConnected
             AND NOT _stAxis.stInputs.bAirpadPressurized) THEN
@@ -312,7 +312,7 @@ bReady := eAirpad = E_Airpad.eReadyToMove
 mControl_Airpad.Error := bAirpadError;
 mControl_Airpad.ErrorID := nAirpadErrorId;
 
-IF     bAirpadError THEN
+IF bAirpadError THEN
     _stAxis.stError.nAirpadErrorID := nAirpadErrorId;
 END_IF
 

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -73,6 +73,7 @@ VAR
     stMcStatusTempDisable: ST_McStatus;
     stMcStatusCommandHandler: ST_McStatus;
     stMcStatusAirpad: ST_McStatus;
+    stMcStatusBrake: ST_McStatus;
 
     //Variables for holding limits during homing
     bWaitForStopAfterLimitHit: BOOL := FALSE;
@@ -123,7 +124,7 @@ END_VAR
 VAR CONSTANT
     nRATIO_DENOMINATOR_DEFAULT: UINT := 1;
     nNO_GEARING: UINT := 0;
-    nMCSTATUS_ARRAY_SIZE: UINT := 18;
+    nMCSTATUS_ARRAY_SIZE: UINT := 19;
     nMULTI_MASTER_MAX_AXES: UINT := 4;
 END_VAR
 ]]></Declaration>
@@ -184,6 +185,7 @@ astMcStatus[15] := ADR(stMcStatusBacklash);
 astMcStatus[16] := ADR(stMcStatusTempDisable);
 astMcStatus[17] := ADR(stMcStatusCommandHandler);
 astMcStatus[18] := ADR(stMcStatusAirpad);
+astMcStatus[19] := ADR(stMcStatusBrake);
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -102,7 +102,6 @@ VAR
 
     //Edge detection triggers for statuses
     fbDoneRTrig: R_TRIG;
-    fbErrorRTrig: R_TRIG;
     fbCommandAbortedRTrig: R_TRIG;
     fbInVelocityRTrig: R_TRIG;
     fbInVelocityFTrig: F_TRIG;
@@ -1846,17 +1845,10 @@ END_IF
       <Declaration><![CDATA[METHOD mStatus_Error : BOOL
 VAR
     i: UINT;
-    tmpError: BOOL;
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[FOR i := 1 TO nMCSTATUS_ARRAY_SIZE DO
-    tmpError := astMcStatus[i]^.Error OR tmpError;
-END_FOR
-
-fbErrorRTrig(CLK := tmpError);
-
-IF _stAxis.stConfig.stDriveInfo.DeviceType = E_DeviceType.DEVICETYPE_SOE_DEFAULT THEN
+        <ST><![CDATA[IF _stAxis.stConfig.stDriveInfo.DeviceType = E_DeviceType.DEVICETYPE_SOE_DEFAULT THEN
     // Read SERCOS drive error information,
     fbSoEReadDiagNumber(
         Axis := stAxis.Axis,
@@ -1883,8 +1875,7 @@ FOR i := (nLAST_ARRAY_INDEX_MOVE_COMMANDS + 1) TO nMCSTATUS_ARRAY_SIZE DO
     END_IF
 END_FOR
 
-//Only allow nErrorID to be set if it is currently 0 (healthy). 
-//This creates a snapshot of the root cause.
+//Allow nErrorID to be set only if 0, to create a snapshot of the root cause.
 IF _stAxis.stStatus.nErrorID = 0 THEN
     //Set the NC Error ID as a baseline fallback
     IF _stAxis.Axis.Status.ErrorStop THEN
@@ -1893,7 +1884,7 @@ IF _stAxis.stStatus.nErrorID = 0 THEN
         _stAxis.stStatus.nErrorID := _stAxis.stError.nNCErrorID;
     END_IF
 
-    //Overwrite with Function Block / Custom Errors if present.
+    //Overwrite with FB/Custom Errors if present.
     //Because this executes after the NC check, the FB error gets priority.
     FOR i := 1 TO nMCSTATUS_ARRAY_SIZE DO
         IF astMcStatus[i]^.ErrorID <> 0 THEN

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -950,9 +950,9 @@ IF fbReset.Done
     FOR i := 1 TO nMCSTATUS_ARRAY_SIZE DO
         astMcStatus[i]^.Error := FALSE;
     END_FOR
-        //Reset ST_Status error ID
+    //Reset ST_Status error ID
     _stAxis.stStatus.nErrorID := 0;
-        //Reset St_AxisError error IDs
+    //Reset St_AxisError error IDs
     _stAxis.stError.nPowerErrorID := 0;
     _stAxis.stError.nMoveAbsoluteErrorID := 0;
     _stAxis.stError.nMoveRelativeErrorID := 0;


### PR DESCRIPTION
The errors from the methods:
mControl_CommandHandler
mControl_Airpad
mContro_ExternalBrake
mControl_HighTemperatureDisable
Should make stStatus.bError TRUE and display the corresponding ErrorID.
If reset and the error is gone, stStatus.bError should be FALSE and nErrorID 0.
If the error is still there bError and nErrorID should still display the error bit and error ID.