### PR TITLE
MBP-416: Interlock from multiple sources

### DIFF
--- a/DUTs/Axis_Structures/ST_AxisControl.TcDUT
+++ b/DUTs/Axis_Structures/ST_AxisControl.TcDUT
@@ -11,8 +11,8 @@ STRUCT
     bStop: BOOL; //Stop the axis movement
     bHalt: BOOL; //Halt the axis movement
     bEnable: BOOL; //Enable axis drive
-    bInterlockFwd: BOOL := FALSE; //Enable interlock for forward movement
-    bInterlockBwd: BOOL := FALSE; //Enable interlock for backward movement
+    bInterlockFwd: BOOL := FALSE; //Enable interlock for forward movement (resets at end of cycle)
+    bInterlockBwd: BOOL := FALSE; //Enable interlock for backward movement (resets at end of cycle)
     eCommand: E_MotionFunctions; //Specifies the motion function to execute
     fVelocity: LREAL; //Specifies the velocity to be used for executing motion commands
     fJogVelocity: LREAL; //Velocity for jogging operations

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -153,6 +153,8 @@ bInternalExecute := FALSE;
 bEnabledOld := _stAxis.stStatus.bEnabled;
 bEnableCmdOld := _stAxis.stControl.bEnable;
 
+_stAxis.stControl.bInterlockFwd := FALSE;
+_stAxis.stControl.bInterlockBwd := FALSE;
 _stAxis.stControl.bExecute := FALSE;
 ]]></ST>
       </Implementation>

--- a/POUs/Motion/FB_SlitPair.TcPOU
+++ b/POUs/Motion/FB_SlitPair.TcPOU
@@ -730,14 +730,14 @@ END_CASE
     <Method Name="mAntiCollision" Id="{ceddaf27-2734-0a8a-1c66-3bf942e8b7e9}">
       <Declaration><![CDATA[METHOD PRIVATE mAntiCollision
 VAR
-	fNegativeBladePosWithMargin: LREAL;
-	fPositiveBladePosWithMargin: LREAL;
+    fNegativeBladePosWithMargin: LREAL;
+    fPositiveBladePosWithMargin: LREAL;
 END_VAR
 ]]></Declaration>
       <Implementation>
         <ST><![CDATA[//Return early if preconditions are not met
 IF NOT (bBladesHomed OR bBladesUncoupled OR bAnticollisionEnable) THEN
-	RETURN;
+    RETURN;
 END_IF
 
 //Negative Blade
@@ -746,20 +746,20 @@ fPositiveBladePosWithMargin := (stBladePositive.stStatus.fActPosition - fAnticol
 
 //If executing absolute / relative movement commands also check target position
 IF stBladeNegative.stControl.bExecute THEN
-	CASE stBladeNegative.stControl.eCommand OF
-	
-		E_MotionFunctions.eMoveAbsolute:
-			stBladeNegative.stControl.bInterlockFwd S= stBladeNegative.stControl.fPosition >= fPositiveBladePosWithMargin;
-	
-		E_MotionFunctions.eMoveRelative:
-			stBladeNegative.stControl.bInterlockFwd S= 
-				(stBladeNegative.stControl.fPosition + stBladeNegative.stStatus.fActPosition) >= fPositiveBladePosWithMargin;
-	
-	END_CASE
+    CASE stBladeNegative.stControl.eCommand OF
+
+        E_MotionFunctions.eMoveAbsolute:
+            stBladeNegative.stControl.bInterlockFwd S= stBladeNegative.stControl.fPosition >= fPositiveBladePosWithMargin;
+
+        E_MotionFunctions.eMoveRelative:
+            stBladeNegative.stControl.bInterlockFwd S=
+                (stBladeNegative.stControl.fPosition + stBladeNegative.stStatus.fActPosition) >= fPositiveBladePosWithMargin;
+
+    END_CASE
 END_IF
 
 //Check if current position is outside the anticollision margin
-stBladeNegative.stControl.bInterlockFwd S= stBladeNegative.stStatus.fActPosition >= fPositiveBladePosWithMargin; 
+stBladeNegative.stControl.bInterlockFwd S= stBladeNegative.stStatus.fActPosition >= fPositiveBladePosWithMargin;
 
 //Positive Blade
 
@@ -767,16 +767,16 @@ fNegativeBladePosWithMargin := (stBladeNegative.stStatus.fActPosition + fAnticol
 
 //If executing absolute / relative movement commands also check target position
 IF stBladePositive.stControl.bExecute THEN
-	CASE stBladePositive.stControl.eCommand OF
-	
-		E_MotionFunctions.eMoveAbsolute:
-			stBladePositive.stControl.bInterlockBwd S= stBladePositive.stControl.fPosition <= fNegativeBladePosWithMargin;
-	
-		E_MotionFunctions.eMoveRelative:
-			stBladePositive.stControl.bInterlockBwd S=
-				(stBladePositive.stControl.fPosition + stBladePositive.stStatus.fActPosition) <= fNegativeBladePosWithMargin;
-	
-	END_CASE
+    CASE stBladePositive.stControl.eCommand OF
+
+        E_MotionFunctions.eMoveAbsolute:
+            stBladePositive.stControl.bInterlockBwd S= stBladePositive.stControl.fPosition <= fNegativeBladePosWithMargin;
+
+        E_MotionFunctions.eMoveRelative:
+            stBladePositive.stControl.bInterlockBwd S=
+                (stBladePositive.stControl.fPosition + stBladePositive.stStatus.fActPosition) <= fNegativeBladePosWithMargin;
+
+    END_CASE
 END_IF
 
 //Check if current position is outside the anticollision margin

--- a/POUs/Motion/FB_SlitPair.TcPOU
+++ b/POUs/Motion/FB_SlitPair.TcPOU
@@ -89,7 +89,7 @@ actVirtualAxisPositions(); //Virtual axis encoder position subroutine
 actUpdateStatus(); //Update statuses
 actEnableAxes(); //Enable the axes
 actClearCalibration(); //Clear calibration flag for all axes
-actAnticollision(); //Handle blades anticollision
+mAnticollision(); //Handle blades anticollision
 
 CASE eSlitPairState OF
     E_SlitPairStates.eStartup:
@@ -253,60 +253,6 @@ END_CASE
 bReset := FALSE;
 ]]></ST>
     </Implementation>
-    <Action Name="actAnticollision" Id="{64063538-5b16-04d7-1d46-c493a7cc7a35}">
-      <Implementation>
-        <ST><![CDATA[//Negative Blade
-
-//If executing absolute / relative movement commands also check target position
-CASE stBladeNegative.stControl.eCommand OF
-
-    E_MotionFunctions.eMoveAbsolute:
-        stBladeNegative.stControl.bInterlockFwd := stBladeNegative.stControl.bExecute
-            AND stBladeNegative.stControl.fPosition >= (stBladePositive.stStatus.fActPosition - fAnticollisionMargin);
-
-    E_MotionFunctions.eMoveRelative:
-        stBladeNegative.stControl.bInterlockFwd := stBladeNegative.stControl.bExecute
-            AND (stBladeNegative.stControl.fPosition + stBladeNegative.stStatus.fActPosition) >= (stBladePositive.stStatus.fActPosition - fAnticollisionMargin);
-
-    ELSE
-        stBladeNegative.stControl.bInterlockFwd := FALSE;
-
-END_CASE
-
-//Check if current position is outside the anticollision margin
-stBladeNegative.stControl.bInterlockFwd :=
-    (stBladeNegative.stControl.bInterlockFwd OR stBladeNegative.stStatus.fActPosition >= (stBladePositive.stStatus.fActPosition - fAnticollisionMargin))
-    AND bBladesHomed
-    AND bBladesUncoupled
-    AND bAnticollisionEnable;
-
-//Positive Blade
-
-//If executing absolute / relative movement commands also check target position
-CASE stBladePositive.stControl.eCommand OF
-
-    E_MotionFunctions.eMoveAbsolute:
-        stBladePositive.stControl.bInterlockBwd := stBladePositive.stControl.bExecute
-            AND stBladePositive.stControl.fPosition <= (stBladeNegative.stStatus.fActPosition + fAnticollisionMargin);
-
-    E_MotionFunctions.eMoveRelative:
-        stBladePositive.stControl.bInterlockBwd := stBladePositive.stControl.bExecute
-            AND (stBladePositive.stControl.fPosition + stBladePositive.stStatus.fActPosition) <= (stBladeNegative.stStatus.fActPosition + fAnticollisionMargin);
-
-    ELSE
-        stBladePositive.stControl.bInterlockBwd := FALSE;
-
-END_CASE
-
-//Check if current position is outside the anticollision margin
-stBladePositive.stControl.bInterlockBwd :=
-    (stBladePositive.stControl.bInterlockBwd OR stBladePositive.stStatus.fActPosition <= (stBladeNegative.stStatus.fActPosition + fAnticollisionMargin))
-    AND bBladesHomed
-    AND bBladesUncoupled
-    AND bAnticollisionEnable;
-]]></ST>
-      </Implementation>
-    </Action>
     <Action Name="actClearCalibration" Id="{ebc4e684-09cb-0ff6-2420-a784d5e2b2e0}">
       <Implementation>
         <ST><![CDATA[fbResetCalibrationPositiveBlade(
@@ -778,6 +724,63 @@ END_VAR
         ;
 
 END_CASE
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="mAntiCollision" Id="{ceddaf27-2734-0a8a-1c66-3bf942e8b7e9}">
+      <Declaration><![CDATA[METHOD PRIVATE mAntiCollision
+VAR
+	fNegativeBladePosWithMargin: LREAL;
+	fPositiveBladePosWithMargin: LREAL;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[//Return early if preconditions are not met
+IF NOT (bBladesHomed OR bBladesUncoupled OR bAnticollisionEnable) THEN
+	RETURN;
+END_IF
+
+//Negative Blade
+
+fPositiveBladePosWithMargin := (stBladePositive.stStatus.fActPosition - fAnticollisionMargin);
+
+//If executing absolute / relative movement commands also check target position
+IF stBladeNegative.stControl.bExecute THEN
+	CASE stBladeNegative.stControl.eCommand OF
+	
+		E_MotionFunctions.eMoveAbsolute:
+			stBladeNegative.stControl.bInterlockFwd S= stBladeNegative.stControl.fPosition >= fPositiveBladePosWithMargin;
+	
+		E_MotionFunctions.eMoveRelative:
+			stBladeNegative.stControl.bInterlockFwd S= 
+				(stBladeNegative.stControl.fPosition + stBladeNegative.stStatus.fActPosition) >= fPositiveBladePosWithMargin;
+	
+	END_CASE
+END_IF
+
+//Check if current position is outside the anticollision margin
+stBladeNegative.stControl.bInterlockFwd S= stBladeNegative.stStatus.fActPosition >= fPositiveBladePosWithMargin; 
+
+//Positive Blade
+
+fNegativeBladePosWithMargin := (stBladeNegative.stStatus.fActPosition + fAnticollisionMargin);
+
+//If executing absolute / relative movement commands also check target position
+IF stBladePositive.stControl.bExecute THEN
+	CASE stBladePositive.stControl.eCommand OF
+	
+		E_MotionFunctions.eMoveAbsolute:
+			stBladePositive.stControl.bInterlockBwd S= stBladePositive.stControl.fPosition <= fNegativeBladePosWithMargin;
+	
+		E_MotionFunctions.eMoveRelative:
+			stBladePositive.stControl.bInterlockBwd S=
+				(stBladePositive.stControl.fPosition + stBladePositive.stStatus.fActPosition) <= fNegativeBladePosWithMargin;
+	
+	END_CASE
+END_IF
+
+//Check if current position is outside the anticollision margin
+stBladePositive.stControl.bInterlockBwd S= stBladePositive.stStatus.fActPosition <= fNegativeBladePosWithMargin;
 ]]></ST>
       </Implementation>
     </Method>


### PR DESCRIPTION
**Proposal** 
Have the axis function block consume the axis control interlock at the end of the cycle, thereby resetting it. This solves the reset issue when the interlock needs to be set in multiple places. The interlock is reset automatically at the end of the cycle, so users only need to set it to TRUE.

The proposal also updates the anticollision logic inside slit function block to use the new interlock logic.

**Test**

- [X] Set interlock from multiple sources
- [ ] Updated anticollision of slit