### PR TITLE
MBP-403: Command history

### DIFF
--- a/DUTs/E_Result.TcDUT
+++ b/DUTs/E_Result.TcDUT
@@ -7,6 +7,8 @@ TYPE E_Result :
 (
     eNone,
     eDone,
+    eStopped,
+    eHalted,
     eAborted,
     eError
 );

--- a/DUTs/E_Result.TcDUT
+++ b/DUTs/E_Result.TcDUT
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <DUT Name="E_Result" Id="{4f73de63-82bb-01cb-3e02-6abfb05c5bcf}">
+    <Declaration><![CDATA[{attribute 'qualified_only'}
+{attribute 'strict'}
+TYPE E_Result :
+(
+    eNone,
+    eDone,
+    eAborted,
+    eError
+);
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/DUTs/ST_CommandHistoryEntry.TcDUT
+++ b/DUTs/ST_CommandHistoryEntry.TcDUT
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <DUT Name="ST_CommandHistoryEntry" Id="{b7472ac7-f553-0458-2fb0-2b71a79014f5}">
+    <Declaration><![CDATA[TYPE ST_CommandHistoryEntry :
+STRUCT
+    dtTrigger: DT;
+    dtRelease: DT;
+    dtFinish: DT;
+    eCommand: E_MotionFunctions := E_MotionFunctions.eWaitingForCommand;
+    eResult: E_Result := E_Result.eNone;
+END_STRUCT
+END_TYPE
+]]></Declaration>
+  </DUT>
+</TcPlcObject>

--- a/DUTs/ST_CommandHistoryEntry.TcDUT
+++ b/DUTs/ST_CommandHistoryEntry.TcDUT
@@ -12,6 +12,7 @@ STRUCT
     fPosition: LREAL;
     eCommand: E_MotionFunctions := E_MotionFunctions.eWaitingForCommand;
     eResult: E_Result := E_Result.eNone;
+    nErrorID: UDINT;
 END_STRUCT
 END_TYPE
 ]]></Declaration>

--- a/DUTs/ST_CommandHistoryEntry.TcDUT
+++ b/DUTs/ST_CommandHistoryEntry.TcDUT
@@ -6,6 +6,10 @@ STRUCT
     dtTrigger: DT;
     dtRelease: DT;
     dtFinish: DT;
+    fVelocity: LREAL;
+    fAcceleration: LREAL;
+    fDeceleration: LREAL;
+    fPosition: LREAL;
     eCommand: E_MotionFunctions := E_MotionFunctions.eWaitingForCommand;
     eResult: E_Result := E_Result.eNone;
 END_STRUCT

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -1102,6 +1102,8 @@ mMove_Halt.ErrorID := fbHalt.ErrorID;
 mMove_Halt.Active := fbHalt.Active;
 mMove_Halt.CommandAborted := fbHalt.CommandAborted;
 
+fbCommandHistory.mSetHalted(bExecute := fbHalt.Execute);
+
 IF fbHalt.Error THEN
     _stAxis.stError.nHaltErrorID := fbHalt.ErrorID; //Set the error
 END_IF
@@ -1311,6 +1313,8 @@ mMove_Stop.Error := fbStop.Error;
 mMove_Stop.ErrorID := fbStop.ErrorID;
 mMove_Stop.Active := fbStop.Active;
 mMove_Stop.CommandAborted := fbStop.CommandAborted;
+
+fbCommandHistory.mSetStopped(bExecute := fbStop.Execute);
 
 IF fbStop.Error THEN
     _stAxis.stError.nStopErrorID := fbStop.ErrorID; //Set the error

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -439,6 +439,7 @@ CASE eState OF
         bInternalExecute := TRUE;
         bInternalMovePermit := TRUE;
         bInternalReleasedMoveCmd := TRUE;
+        fbCommandHistory.mSetRelease();
         eState := E_CommandHandlerState.eWaitForMotionStart;
 
     E_CommandHandlerState.eWaitForMotionStart:

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -731,7 +731,7 @@ mControl_GearInMultiMaster.Error := fbGearInMultiMaster.Error;
 mControl_GearInMultiMaster.ErrorID := fbGearInMultiMaster.ErrorID;
 mControl_GearInMultiMaster.CommandAborted := fbGearInMultiMaster.CommandAborted;
 
-fbCommandHistory.mSetResult(
+fbCommandHistory.mSetResultOfCommand(
     eCommand := E_MotionFunctions.eGearInMultiMaster,
     stStatus := mControl_GearInMultiMaster);
 
@@ -766,7 +766,7 @@ mControl_GearOut.Busy := fbGearOut.Busy;
 mControl_GearOut.Error := fbGearOut.Error;
 mControl_GearOut.ErrorID := fbGearOut.ErrorID;
 
-fbCommandHistory.mSetResult(
+fbCommandHistory.mSetResultOfCommand(
     eCommand := E_MotionFunctions.eGearOut,
     stStatus := mControl_GearOut);
 
@@ -806,7 +806,7 @@ mControl_Home.Done := fbHome.bDone;
 mControl_Home.Error := fbHome.bError;
 mControl_Home.ErrorID := fbHome.nErrorId;
 
-fbCommandHistory.mSetResult(
+fbCommandHistory.mSetResultOfCommand(
     eCommand := E_MotionFunctions.eHome,
     stStatus := mControl_Home);
 
@@ -1157,7 +1157,7 @@ fbAbsMovDyn2RiseEdge(CLK:= fbMoveAbsolute2.Busy AND fbMoveAbsolute.CommandAborte
 mMove_MoveAbsolute.CommandAborted := (fbMoveAbsolute.CommandAborted AND NOT fbAbsMovDyn2RiseEdge.Q)
                                     OR (fbMoveAbsolute2.CommandAborted AND NOT fbAbsMovDyn1RiseEdge.Q);
 
-fbCommandHistory.mSetResult(
+fbCommandHistory.mSetResultOfCommand(
     eCommand := E_MotionFunctions.eMoveAbsolute,
     stStatus := mMove_MoveAbsolute);
 
@@ -1213,7 +1213,7 @@ fbModMovDyn2RiseEdge(CLK:= fbMoveModulo2.Busy AND fbMoveModulo.CommandAborted, Q
 mMove_MoveModulo.CommandAborted := (fbMoveModulo.CommandAborted AND NOT fbModMovDyn2RiseEdge.Q)
                                     OR (fbMoveModulo2.CommandAborted AND NOT fbModMovDyn1RiseEdge.Q);
 
-fbCommandHistory.mSetResult(
+fbCommandHistory.mSetResultOfCommand(
     eCommand := E_MotionFunctions.eMoveModulo,
     stStatus := mMove_MoveModulo);
 
@@ -1253,7 +1253,7 @@ mMove_MoveRelative.Error := fbMoveRelative.Error;
 mMove_MoveRelative.ErrorID := fbMoveRelative.ErrorID;
 mMove_MoveRelative.CommandAborted := fbMoveRelative.CommandAborted;
 
-fbCommandHistory.mSetResult(
+fbCommandHistory.mSetResultOfCommand(
     eCommand := E_MotionFunctions.eMoveRelative,
     stStatus := mMove_MoveRelative);
 
@@ -1286,7 +1286,7 @@ mMove_MoveVelocity.Error := fbMoveVelocity.Error;
 mMove_MoveVelocity.ErrorID := fbMoveVelocity.ErrorID;
 mMove_MoveVelocity.CommandAborted := fbMoveVelocity.CommandAborted;
 
-fbCommandHistory.mSetResult(
+fbCommandHistory.mSetResultOfCommand(
     eCommand := E_MotionFunctions.eMoveVelocity,
     stStatus := mMove_MoveVelocity);
 

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -114,6 +114,8 @@ VAR
     fbModMovDyn1RiseEdge: R_TRIG;
     fbModMovDyn2RiseEdge: R_TRIG;
 
+    fbCommandHistory: FB_CommandHistory;
+
     bInternalExecute: BOOL := FALSE;
     bEnableCmdOld: BOOL := FALSE;
     bEnabledOld: BOOL := FALSE;
@@ -407,6 +409,8 @@ CASE eState OF
                     IF _stAxis.stConfig.bAutoEnable THEN
                         _stAxis.stControl.bEnable := TRUE;
                     END_IF
+
+                    fbCommandHistory.mAdd(eLatchedCommand);
                     eState := E_CommandHandlerState.eWaitPermits;
             END_CASE
         END_IF

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -731,6 +731,10 @@ mControl_GearInMultiMaster.Error := fbGearInMultiMaster.Error;
 mControl_GearInMultiMaster.ErrorID := fbGearInMultiMaster.ErrorID;
 mControl_GearInMultiMaster.CommandAborted := fbGearInMultiMaster.CommandAborted;
 
+fbCommandHistory.mSetResult(
+    eCommand := E_MotionFunctions.eGearInMultiMaster,
+    stStatus := mControl_GearInMultiMaster);
+
 IF fbGearInMultiMaster.Error THEN
     _stAxis.stError.nGearInMultiMasterErrorID := fbGearInMultiMaster.ErrorID; //Set the error
 END_IF
@@ -761,6 +765,10 @@ mControl_GearOut.Done := fbGearOut.Done;
 mControl_GearOut.Busy := fbGearOut.Busy;
 mControl_GearOut.Error := fbGearOut.Error;
 mControl_GearOut.ErrorID := fbGearOut.ErrorID;
+
+fbCommandHistory.mSetResult(
+    eCommand := E_MotionFunctions.eGearOut,
+    stStatus := mControl_GearOut);
 
 IF fbGearOut.Error THEN
     _stAxis.stError.nGearOutErrorID := fbGearOut.ErrorID; //Set the error
@@ -797,6 +805,10 @@ mControl_Home.CommandAborted := fbHome.bCommandAborted;
 mControl_Home.Done := fbHome.bDone;
 mControl_Home.Error := fbHome.bError;
 mControl_Home.ErrorID := fbHome.nErrorId;
+
+fbCommandHistory.mSetResult(
+    eCommand := E_MotionFunctions.eHome,
+    stStatus := mControl_Home);
 
 IF fbHome.bError THEN
     _stAxis.stError.nHomeErrorID := fbHome.nErrorID; //Set the error
@@ -1133,19 +1145,21 @@ fbMoveAbsolute2(Axis := _stAxis.Axis);
 fbMoveAbsolute.Execute := FALSE;
 fbMoveAbsolute2.Execute := FALSE;
 
-
 // STATUS bits
 mMove_MoveAbsolute.Active := fbMoveAbsolute.Active OR fbMoveAbsolute2.Active;
 mMove_MoveAbsolute.Done := fbMoveAbsolute.Done OR fbMoveAbsolute2.Done;
 mMove_MoveAbsolute.Busy := fbMoveAbsolute.Busy OR fbMoveAbsolute2.Busy;
 mMove_MoveAbsolute.Error := fbMoveAbsolute.Error OR fbMoveAbsolute2.Error;
 
-
 // Capture the CommandAborted for first scan if the other absolute move overtakes the current
 fbAbsMovDyn1RiseEdge(CLK:= fbMoveAbsolute.Busy AND fbMoveAbsolute2.CommandAborted, Q=>);
 fbAbsMovDyn2RiseEdge(CLK:= fbMoveAbsolute2.Busy AND fbMoveAbsolute.CommandAborted, Q=>);
 mMove_MoveAbsolute.CommandAborted := (fbMoveAbsolute.CommandAborted AND NOT fbAbsMovDyn2RiseEdge.Q)
                                     OR (fbMoveAbsolute2.CommandAborted AND NOT fbAbsMovDyn1RiseEdge.Q);
+
+fbCommandHistory.mSetResult(
+    eCommand := E_MotionFunctions.eMoveAbsolute,
+    stStatus := mMove_MoveAbsolute);
 
 // Error IDs
 IF fbMoveAbsolute.Error THEN
@@ -1199,6 +1213,10 @@ fbModMovDyn2RiseEdge(CLK:= fbMoveModulo2.Busy AND fbMoveModulo.CommandAborted, Q
 mMove_MoveModulo.CommandAborted := (fbMoveModulo.CommandAborted AND NOT fbModMovDyn2RiseEdge.Q)
                                     OR (fbMoveModulo2.CommandAborted AND NOT fbModMovDyn1RiseEdge.Q);
 
+fbCommandHistory.mSetResult(
+    eCommand := E_MotionFunctions.eMoveModulo,
+    stStatus := mMove_MoveModulo);
+
 // Error IDs
 IF fbMoveModulo.Error THEN
     _stAxis.stError.nMoveModuloErrorID := fbMoveModulo.ErrorID; //Set the error
@@ -1235,6 +1253,10 @@ mMove_MoveRelative.Error := fbMoveRelative.Error;
 mMove_MoveRelative.ErrorID := fbMoveRelative.ErrorID;
 mMove_MoveRelative.CommandAborted := fbMoveRelative.CommandAborted;
 
+fbCommandHistory.mSetResult(
+    eCommand := E_MotionFunctions.eMoveRelative,
+    stStatus := mMove_MoveRelative);
+
 IF fbMoveRelative.Error THEN
     _stAxis.stError.nMoveRelativeErrorID := fbMoveRelative.ErrorID; //Set the error
 END_IF
@@ -1263,6 +1285,10 @@ mMove_MoveVelocity.Busy := fbMoveVelocity.Busy;
 mMove_MoveVelocity.Error := fbMoveVelocity.Error;
 mMove_MoveVelocity.ErrorID := fbMoveVelocity.ErrorID;
 mMove_MoveVelocity.CommandAborted := fbMoveVelocity.CommandAborted;
+
+fbCommandHistory.mSetResult(
+    eCommand := E_MotionFunctions.eMoveVelocity,
+    stStatus := mMove_MoveVelocity);
 
 IF fbMoveVelocity.Error THEN
     _stAxis.stError.nMoveVelocityErrorID := fbMoveVelocity.ErrorID; //Set the error

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -731,13 +731,13 @@ mControl_GearInMultiMaster.Error := fbGearInMultiMaster.Error;
 mControl_GearInMultiMaster.ErrorID := fbGearInMultiMaster.ErrorID;
 mControl_GearInMultiMaster.CommandAborted := fbGearInMultiMaster.CommandAborted;
 
-fbCommandHistory.mSetResultOfCommand(
-    eCommand := E_MotionFunctions.eGearInMultiMaster,
-    stStatus := mControl_GearInMultiMaster);
-
 IF fbGearInMultiMaster.Error THEN
     _stAxis.stError.nGearInMultiMasterErrorID := fbGearInMultiMaster.ErrorID; //Set the error
 END_IF
+
+fbCommandHistory.mSetResultOfCommand(
+    eCommand := E_MotionFunctions.eGearInMultiMaster,
+    stStatus := mControl_GearInMultiMaster);
 ]]></ST>
       </Implementation>
     </Method>
@@ -766,13 +766,13 @@ mControl_GearOut.Busy := fbGearOut.Busy;
 mControl_GearOut.Error := fbGearOut.Error;
 mControl_GearOut.ErrorID := fbGearOut.ErrorID;
 
-fbCommandHistory.mSetResultOfCommand(
-    eCommand := E_MotionFunctions.eGearOut,
-    stStatus := mControl_GearOut);
-
 IF fbGearOut.Error THEN
     _stAxis.stError.nGearOutErrorID := fbGearOut.ErrorID; //Set the error
 END_IF
+
+fbCommandHistory.mSetResultOfCommand(
+    eCommand := E_MotionFunctions.eGearOut,
+    stStatus := mControl_GearOut);
 ]]></ST>
       </Implementation>
     </Method>
@@ -806,13 +806,13 @@ mControl_Home.Done := fbHome.bDone;
 mControl_Home.Error := fbHome.bError;
 mControl_Home.ErrorID := fbHome.nErrorId;
 
-fbCommandHistory.mSetResultOfCommand(
-    eCommand := E_MotionFunctions.eHome,
-    stStatus := mControl_Home);
-
 IF fbHome.bError THEN
     _stAxis.stError.nHomeErrorID := fbHome.nErrorID; //Set the error
 END_IF
+
+fbCommandHistory.mSetResultOfCommand(
+    eCommand := E_MotionFunctions.eHome,
+    stStatus := mControl_Home);
 ]]></ST>
       </Implementation>
     </Method>
@@ -1159,10 +1159,6 @@ fbAbsMovDyn2RiseEdge(CLK:= fbMoveAbsolute2.Busy AND fbMoveAbsolute.CommandAborte
 mMove_MoveAbsolute.CommandAborted := (fbMoveAbsolute.CommandAborted AND NOT fbAbsMovDyn2RiseEdge.Q)
                                     OR (fbMoveAbsolute2.CommandAborted AND NOT fbAbsMovDyn1RiseEdge.Q);
 
-fbCommandHistory.mSetResultOfCommand(
-    eCommand := E_MotionFunctions.eMoveAbsolute,
-    stStatus := mMove_MoveAbsolute);
-
 // Error IDs
 IF fbMoveAbsolute.Error THEN
     _stAxis.stError.nMoveAbsoluteErrorID := fbMoveAbsolute.ErrorID; //Set the error
@@ -1172,6 +1168,10 @@ IF fbMoveAbsolute2.Error THEN
     _stAxis.stError.nMoveAbsoluteErrorID := fbMoveAbsolute2.ErrorID; //Set the error
     mMove_MoveAbsolute.ErrorID := fbMoveAbsolute2.ErrorID;
 END_IF
+
+fbCommandHistory.mSetResultOfCommand(
+    eCommand := E_MotionFunctions.eMoveAbsolute,
+    stStatus := mMove_MoveAbsolute);
 ]]></ST>
       </Implementation>
     </Method>
@@ -1215,10 +1215,6 @@ fbModMovDyn2RiseEdge(CLK:= fbMoveModulo2.Busy AND fbMoveModulo.CommandAborted, Q
 mMove_MoveModulo.CommandAborted := (fbMoveModulo.CommandAborted AND NOT fbModMovDyn2RiseEdge.Q)
                                     OR (fbMoveModulo2.CommandAborted AND NOT fbModMovDyn1RiseEdge.Q);
 
-fbCommandHistory.mSetResultOfCommand(
-    eCommand := E_MotionFunctions.eMoveModulo,
-    stStatus := mMove_MoveModulo);
-
 // Error IDs
 IF fbMoveModulo.Error THEN
     _stAxis.stError.nMoveModuloErrorID := fbMoveModulo.ErrorID; //Set the error
@@ -1229,6 +1225,10 @@ IF fbMoveModulo2.Error THEN
     _stAxis.stError.nMoveModuloErrorID := fbMoveModulo2.ErrorID; //Set the error
     mMove_MoveModulo.ErrorID := fbMoveModulo2.ErrorID;
 END_IF
+
+fbCommandHistory.mSetResultOfCommand(
+    eCommand := E_MotionFunctions.eMoveModulo,
+    stStatus := mMove_MoveModulo);
 ]]></ST>
       </Implementation>
     </Method>
@@ -1255,13 +1255,13 @@ mMove_MoveRelative.Error := fbMoveRelative.Error;
 mMove_MoveRelative.ErrorID := fbMoveRelative.ErrorID;
 mMove_MoveRelative.CommandAborted := fbMoveRelative.CommandAborted;
 
-fbCommandHistory.mSetResultOfCommand(
-    eCommand := E_MotionFunctions.eMoveRelative,
-    stStatus := mMove_MoveRelative);
-
 IF fbMoveRelative.Error THEN
     _stAxis.stError.nMoveRelativeErrorID := fbMoveRelative.ErrorID; //Set the error
 END_IF
+
+fbCommandHistory.mSetResultOfCommand(
+    eCommand := E_MotionFunctions.eMoveRelative,
+    stStatus := mMove_MoveRelative);
 ]]></ST>
       </Implementation>
     </Method>
@@ -1288,13 +1288,13 @@ mMove_MoveVelocity.Error := fbMoveVelocity.Error;
 mMove_MoveVelocity.ErrorID := fbMoveVelocity.ErrorID;
 mMove_MoveVelocity.CommandAborted := fbMoveVelocity.CommandAborted;
 
-fbCommandHistory.mSetResultOfCommand(
-    eCommand := E_MotionFunctions.eMoveVelocity,
-    stStatus := mMove_MoveVelocity);
-
 IF fbMoveVelocity.Error THEN
     _stAxis.stError.nMoveVelocityErrorID := fbMoveVelocity.ErrorID; //Set the error
 END_IF
+
+fbCommandHistory.mSetResultOfCommand(
+    eCommand := E_MotionFunctions.eMoveVelocity,
+    stStatus := mMove_MoveVelocity);
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/Motion/FB_Axis.TcPOU
+++ b/POUs/Motion/FB_Axis.TcPOU
@@ -410,7 +410,7 @@ CASE eState OF
                         _stAxis.stControl.bEnable := TRUE;
                     END_IF
 
-                    fbCommandHistory.mAdd(eLatchedCommand);
+                    fbCommandHistory.mAdd(_stAxis.stControl);
                     eState := E_CommandHandlerState.eWaitPermits;
             END_CASE
         END_IF

--- a/POUs/Utilities/FB_CommandHistory.TcPOU
+++ b/POUs/Utilities/FB_CommandHistory.TcPOU
@@ -57,9 +57,9 @@ METHOD mSetRelease
 ]]></ST>
       </Implementation>
     </Method>
-    <Method Name="mSetResult" Id="{c37cdde3-a4ed-0365-3874-96cbe0e75c19}">
+    <Method Name="mSetResultOfCommand" Id="{c37cdde3-a4ed-0365-3874-96cbe0e75c19}">
       <Declaration><![CDATA[//Sets the command result and finish time, if command matches top entry
-METHOD mSetResult
+METHOD mSetResultOfCommand
 VAR_INPUT
     eCommand: E_MotionFunctions;
 END_VAR

--- a/POUs/Utilities/FB_CommandHistory.TcPOU
+++ b/POUs/Utilities/FB_CommandHistory.TcPOU
@@ -38,5 +38,14 @@ aCommandHistory[1].dtTrigger := FILETIME64_TO_DT(F_GetSystemTime());
 ]]></ST>
       </Implementation>
     </Method>
+    <Method Name="mSetRelease" Id="{340a6c28-35e6-0fbc-3027-e0dab46adcda}">
+      <Declaration><![CDATA[//Sets the release time of the top entry
+METHOD mSetRelease
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[aCommandHistory[1].dtRelease := FILETIME64_TO_DT(F_GetSystemTime());
+]]></ST>
+      </Implementation>
+    </Method>
   </POU>
 </TcPlcObject>

--- a/POUs/Utilities/FB_CommandHistory.TcPOU
+++ b/POUs/Utilities/FB_CommandHistory.TcPOU
@@ -21,7 +21,13 @@ VAR_IN_OUT CONSTANT
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[//Shift old entries
+        <ST><![CDATA[//Set top entry to aborted, if it has no result
+IF aCommandHistory[1].eCommand <> E_MotionFunctions.eWaitingForCommand
+    AND aCommandHistory[1].eResult = E_Result.eNone THEN
+    aCommandHistory[1].eResult := E_Result.eAborted;
+END_IF
+
+//Shift old entries
 IF nMAX_HISTROY_ENTRY > 1 THEN
     MEMMOVE(
         destAddr := ADR(aCommandHistory[2]),

--- a/POUs/Utilities/FB_CommandHistory.TcPOU
+++ b/POUs/Utilities/FB_CommandHistory.TcPOU
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1">
+  <POU Name="FB_CommandHistory" Id="{39e94074-e42b-0657-2248-14d00ab28c33}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_CommandHistory
+VAR_OUTPUT
+    aCommandHistory: ARRAY [1..nMAX_HISTROY_ENTRY] OF ST_CommandHistoryEntry;
+END_VAR
+VAR CONSTANT
+    nMAX_HISTROY_ENTRY: USINT := 10;
+    stEmptyEntry: ST_CommandHistoryEntry := ();
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/POUs/Utilities/FB_CommandHistory.TcPOU
+++ b/POUs/Utilities/FB_CommandHistory.TcPOU
@@ -48,6 +48,26 @@ aCommandHistory[1].eResult := E_Result.eNone;
 ]]></ST>
       </Implementation>
     </Method>
+    <Method Name="mSetHalted" Id="{1f3a1779-2f80-0b97-1b8f-3aa2dcc923d9}">
+      <Declaration><![CDATA[//Sets the result of the top entry to halted
+METHOD mSetHalted
+VAR_IN_OUT CONSTANT
+    bExecute: BOOL;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[//Check result already set for last command
+IF aCommandHistory[1].eResult <> E_Result.eNone THEN
+    RETURN;
+END_IF
+
+IF bExecute THEN
+    aCommandHistory[1].eResult := E_Result.eHalted;
+    aCommandHistory[1].dtFinish := FILETIME64_TO_DT(F_GetSystemTime());
+END_IF
+]]></ST>
+      </Implementation>
+    </Method>
     <Method Name="mSetRelease" Id="{340a6c28-35e6-0fbc-3027-e0dab46adcda}">
       <Declaration><![CDATA[//Sets the release time of the top entry
 METHOD mSetRelease
@@ -83,6 +103,26 @@ ELSIF stStatus.CommandAborted THEN
 ELSIF stStatus.Error THEN
     aCommandHistory[1].eResult := E_Result.eError;
     aCommandHistory[1].nErrorID := stStatus.ErrorID;
+    aCommandHistory[1].dtFinish := FILETIME64_TO_DT(F_GetSystemTime());
+END_IF
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="mSetStopped" Id="{3f61dcd9-0b60-03e6-3923-c1c6c4c79e3e}">
+      <Declaration><![CDATA[//Sets the result of the top entry to stopped
+METHOD mSetStopped
+VAR_IN_OUT CONSTANT
+    bExecute: BOOL;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[//Check result already set for last command
+IF aCommandHistory[1].eResult <> E_Result.eNone THEN
+    RETURN;
+END_IF
+
+IF bExecute THEN
+    aCommandHistory[1].eResult := E_Result.eStopped;
     aCommandHistory[1].dtFinish := FILETIME64_TO_DT(F_GetSystemTime());
 END_IF
 ]]></ST>

--- a/POUs/Utilities/FB_CommandHistory.TcPOU
+++ b/POUs/Utilities/FB_CommandHistory.TcPOU
@@ -45,6 +45,7 @@ aCommandHistory[1].fDeceleration := stAxisControl.fDeceleration;
 aCommandHistory[1].fPosition := stAxisControl.fPosition;
 aCommandHistory[1].eCommand := stAxisControl.eCommand;
 aCommandHistory[1].eResult := E_Result.eNone;
+aCommandHistory[1].nErrorID := 0;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/Utilities/FB_CommandHistory.TcPOU
+++ b/POUs/Utilities/FB_CommandHistory.TcPOU
@@ -7,17 +7,17 @@ VAR_OUTPUT
 END_VAR
 VAR CONSTANT
     nMAX_HISTROY_ENTRY: USINT := 10;
-    stEmptyEntry: ST_CommandHistoryEntry := ();
 END_VAR
 ]]></Declaration>
     <Implementation>
-      <ST><![CDATA[]]></ST>
+      <ST><![CDATA[
+]]></ST>
     </Implementation>
     <Method Name="mAdd" Id="{814dbda4-eaf2-055a-2536-42e29c3098af}">
       <Declaration><![CDATA[//Shifts the old entries in the history and adds the new command to the top
 METHOD mAdd
-VAR_INPUT
-    eCommand: E_MotionFunctions;
+VAR_IN_OUT CONSTANT
+    stAxisControl: ST_AxisControl;
 END_VAR
 ]]></Declaration>
       <Implementation>
@@ -29,12 +29,16 @@ IF nMAX_HISTROY_ENTRY > 1 THEN
         n := (nMAX_HISTROY_ENTRY - 1) * SIZEOF(ST_CommandHistoryEntry));
 END_IF
 
-//Clear old entry
-aCommandHistory[1] := stEmptyEntry;
-
 //Add new entry
-aCommandHistory[1].eCommand := eCommand;
 aCommandHistory[1].dtTrigger := FILETIME64_TO_DT(F_GetSystemTime());
+aCommandHistory[1].dtRelease := TO_DT(0);
+aCommandHistory[1].dtFinish := TO_DT(0);
+aCommandHistory[1].fVelocity := stAxisControl.fVelocity;
+aCommandHistory[1].fAcceleration := stAxisControl.fAcceleration;
+aCommandHistory[1].fDeceleration := stAxisControl.fDeceleration;
+aCommandHistory[1].fPosition := stAxisControl.fPosition;
+aCommandHistory[1].eCommand := stAxisControl.eCommand;
+aCommandHistory[1].eResult := E_Result.eNone;
 ]]></ST>
       </Implementation>
     </Method>

--- a/POUs/Utilities/FB_CommandHistory.TcPOU
+++ b/POUs/Utilities/FB_CommandHistory.TcPOU
@@ -82,6 +82,7 @@ ELSIF stStatus.CommandAborted THEN
     aCommandHistory[1].dtFinish := FILETIME64_TO_DT(F_GetSystemTime());
 ELSIF stStatus.Error THEN
     aCommandHistory[1].eResult := E_Result.eError;
+    aCommandHistory[1].nErrorID := stStatus.ErrorID;
     aCommandHistory[1].dtFinish := FILETIME64_TO_DT(F_GetSystemTime());
 END_IF
 ]]></ST>

--- a/POUs/Utilities/FB_CommandHistory.TcPOU
+++ b/POUs/Utilities/FB_CommandHistory.TcPOU
@@ -13,5 +13,30 @@ END_VAR
     <Implementation>
       <ST><![CDATA[]]></ST>
     </Implementation>
+    <Method Name="mAdd" Id="{814dbda4-eaf2-055a-2536-42e29c3098af}">
+      <Declaration><![CDATA[//Shifts the old entries in the history and adds the new command to the top
+METHOD mAdd
+VAR_INPUT
+    eCommand: E_MotionFunctions;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[//Shift old entries
+IF nMAX_HISTROY_ENTRY > 1 THEN
+    MEMMOVE(
+        destAddr := ADR(aCommandHistory[2]),
+        srcAddr := ADR(aCommandHistory),
+        n := (nMAX_HISTROY_ENTRY - 1) * SIZEOF(ST_CommandHistoryEntry));
+END_IF
+
+//Clear old entry
+aCommandHistory[1] := stEmptyEntry;
+
+//Add new entry
+aCommandHistory[1].eCommand := eCommand;
+aCommandHistory[1].dtTrigger := FILETIME64_TO_DT(F_GetSystemTime());
+]]></ST>
+      </Implementation>
+    </Method>
   </POU>
 </TcPlcObject>

--- a/POUs/Utilities/FB_CommandHistory.TcPOU
+++ b/POUs/Utilities/FB_CommandHistory.TcPOU
@@ -47,5 +47,35 @@ METHOD mSetRelease
 ]]></ST>
       </Implementation>
     </Method>
+    <Method Name="mSetResult" Id="{c37cdde3-a4ed-0365-3874-96cbe0e75c19}">
+      <Declaration><![CDATA[//Sets the command result and finish time, if command matches top entry
+METHOD mSetResult
+VAR_INPUT
+    eCommand: E_MotionFunctions;
+END_VAR
+VAR_IN_OUT CONSTANT
+    stStatus: ST_McStatus;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[//Check result already set for last command or mismatching commands
+IF aCommandHistory[1].eResult <> E_Result.eNone
+    OR aCommandHistory[1].eCommand <> eCommand THEN
+    RETURN;
+END_IF
+
+IF stStatus.Done THEN
+    aCommandHistory[1].eResult := E_Result.eDone;
+    aCommandHistory[1].dtFinish := FILETIME64_TO_DT(F_GetSystemTime());
+ELSIF stStatus.CommandAborted THEN
+    aCommandHistory[1].eResult := E_Result.eAborted;
+    aCommandHistory[1].dtFinish := FILETIME64_TO_DT(F_GetSystemTime());
+ELSIF stStatus.Error THEN
+    aCommandHistory[1].eResult := E_Result.eError;
+    aCommandHistory[1].dtFinish := FILETIME64_TO_DT(F_GetSystemTime());
+END_IF
+]]></ST>
+      </Implementation>
+    </Method>
   </POU>
 </TcPlcObject>


### PR DESCRIPTION
**Proposal**
Adds a new function block to handle command history, it provides various methods:

- mAdd shifts the previous entries in the history and adds the new command with trigger date to top of history (latest command is always at the top)
- mSetRelease sets the release time for the latest/top entry
- mSetResult sets the result of the latest/top command

_NOTE: As I mentioned above this is a new function block in POUs/Utilities folder, it was created as a function block to leave the door open for the future in case we want to bring this feature to pneumatic axes._

**Example Entry**

<img width="1051" height="268" alt="image" src="https://github.com/user-attachments/assets/c2a7fb75-71ac-477e-8872-e391bcabe609" />
